### PR TITLE
Fix cli input issue

### DIFF
--- a/cli/suffix.c
+++ b/cli/suffix.c
@@ -118,7 +118,7 @@ long long suffix_binary_parse(const char *value)
 {
 	char *suffix;
 	errno = 0;
-	long long ret = strtol(value, &suffix, 0);
+	long long ret = strtoll(value, &suffix, 0);
 	if (errno)
 		return 0;
 


### PR DESCRIPTION
On 32 bit OS, the return value of function strtol uses 32 bits. Here we should use 64 bits.