### PR TITLE
Fix firmware update error checking issue.

### DIFF
--- a/lib/fw.c
+++ b/lib/fw.c
@@ -217,7 +217,7 @@ int switchtec_fw_write_fd(struct switchtec_dev *dev, int img_fd,
 			return ret;
 
 		ret = switchtec_fw_wait(dev, &status);
-		if (ret < 0)
+		if (ret != 0)
 		    return ret;
 
 		offset += cmd.hdr.blk_length;
@@ -309,7 +309,7 @@ int switchtec_fw_write_file(struct switchtec_dev *dev, FILE *fimg,
 			return ret;
 
 		ret = switchtec_fw_wait(dev, &status);
-		if (ret < 0)
+		if (ret != 0)
 			return ret;
 
 		offset += cmd.hdr.blk_length;


### PR DESCRIPTION
Function switchtec_fw_wait() returns 0 if it succeed. Function switchtec_fw_write_fd() and switchtec_fw_write_file() use incorrect error checking for function switchtec_fw_wait().