### PR TITLE
Bug Fix - switcthec_status

### DIFF
--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -297,8 +297,10 @@ int switchtec_status(struct switchtec_dev *dev,
 
 
 	for (i = 0; i < SWITCHTEC_MAX_PORTS; i++) {
+		if ((ports[i].phys_port_id == 0) && (i != 0))
+			break;
 		if ((ports[i].stk_id >> 4) > SWITCHTEC_MAX_STACKS)
-			continue;
+			break;
 		nr_ports++;
 	}
 
@@ -307,9 +309,6 @@ int switchtec_status(struct switchtec_dev *dev,
 		return -ENOMEM;
 
 	for (i = 0, p = 0; i < SWITCHTEC_MAX_PORTS && p < nr_ports; i++) {
-		if ((ports[i].stk_id >> 4) > SWITCHTEC_MAX_STACKS)
-			continue;
-
 		s[p].port.partition = ports[i].par_id;
 		s[p].port.stack = ports[i].stk_id >> 4;
 		s[p].port.upstream = ports[i].usp_flag;


### PR DESCRIPTION
BUG Description:
Function switchtec_status() uses SWITCHTEC_MAX_PORTS when sending MRPC command MRPC_LNKSTAT. But the firmware just return the status of valid ports. the number of ports may less than the SWITCHTEC_MAX_PORTS. So the data of ports[SWITCHTEC_MAX_PORTS] has some invalid items. 

To get the correct number of ports, we need add more checks. 
(1) valid item of output are continuous.
(2) if the physical port 0 is valid, it must be first item of output.
(3) physical port number = Port ID + Stack ID * MAX_PORTS_PER_STACK