### PR TITLE
Bug fix - output overflow of MRPC Get Bandwidth Counter

### DIFF
--- a/lib/pmon.c
+++ b/lib/pmon.c
@@ -375,7 +375,7 @@ int switchtec_bwcntr_many(struct switchtec_dev *dev, int nr_ports,
 	while (remain) {
 		cmd.count = remain;
 		if (cmd.count > MRPC_MAX_DATA_LEN / sizeof(*res))
-			cmd.count = MRPC_MAX_DATA_LEN / sizeof(*res);
+			cmd.count = MRPC_MAX_DATA_LEN / sizeof(*res) - 1;
 
 		for (i = 0; i < cmd.count; i++) {
 			cmd.ports[i].id = phys_port_ids[i];


### PR DESCRIPTION
Because the MRPC input and output share 1k data buffer. There is an
MRPC output data overflow in this MRPC command. This change fixes it.