### PR TITLE
Add PCI BDF and ACS information to switchtec status command

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -183,11 +183,14 @@ static int status(int argc, char **argv)
 	static struct {
 		struct switchtec_dev *dev;
 		int reset_bytes;
+		int verbose;
 	} cfg = {};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
 		{"reset", 'r', "", CFG_NONE, &cfg.reset_bytes, no_argument,
 		 "reset byte counters"},
+		{"verbose", 'v', "", CFG_NONE, &cfg.verbose, no_argument,
+		 "print additional information"},
 		{NULL}};
 
 	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
@@ -226,6 +229,10 @@ static int status(int argc, char **argv)
 
 		printf("\tPhys Port ID:    \t%d (Stack %d, Port %d)\n",
 		       s->port.phys_id, s->port.stack, s->port.stk_id);
+		if (s->pci_bdf)
+			printf("\tBus-Dev-Func:    \t%s\n", s->pci_bdf);
+		if (cfg.verbose && s->pci_bdf_path)
+			printf("\tBus-Dev-Func Path:\t%s\n", s->pci_bdf_path);
 
 		printf("\tStatus:          \t%s\n",
 		       s->link_up ? "UP" : "DOWN");

--- a/cli/main.c
+++ b/cli/main.c
@@ -31,6 +31,7 @@
 
 #include <switchtec/switchtec.h>
 #include <switchtec/utils.h>
+#include <switchtec/pci.h>
 
 #include <locale.h>
 #include <time.h>
@@ -168,6 +169,57 @@ static int gui(int argc, char **argv)
 	return ret;
 }
 
+#define PCI_ACS_P2P_MASK (PCI_ACS_CTRL_REQ_RED | PCI_ACS_CTRL_CMPLT_RED | \
+			  PCI_ACS_EGRESS_CTRL)
+
+static const char * const pci_acs_strings[] = {
+	"SrcValid",
+	"TransBlk",
+	"ReqRedir",
+	"CmpltRedir",
+	"UpstreamFwd",
+	"EgressCtrl",
+	"DirectTrans",
+	NULL,
+};
+
+static char *pci_acs_to_string(char *buf, size_t buflen, int acs_ctrl,
+			       int verbose)
+{
+	int ptr = 0;
+	int wr;
+	int i;
+
+	if (acs_ctrl == -1) {
+		snprintf(buf, buflen, "Unknown");
+		return buf;
+	}
+
+	if (!verbose) {
+		if (acs_ctrl & PCI_ACS_P2P_MASK)
+			snprintf(buf, buflen, "P2P Redirected");
+		else
+			snprintf(buf, buflen, "Direct P2P Supported");
+		return buf;
+	}
+
+	for (i = 0; pci_acs_strings[i]; i++) {
+		wr = snprintf(buf + ptr, buflen - ptr, "%s%c ",
+			      pci_acs_strings[i],
+			      (acs_ctrl & (1 << i)) ? '+' : '-');
+
+		if (wr <= 0 || wr >= buflen - ptr)
+			break;
+
+		ptr += wr;
+	}
+
+	if (ptr)
+		buf[ptr - 1] = 0;
+
+	return buf;
+}
+
 static int status(int argc, char **argv)
 {
 	const char *desc = "Display status of the ports on the switch";
@@ -179,6 +231,7 @@ static int status(int argc, char **argv)
 	int p;
 	double bw_val;
 	const char *bw_suf;
+	char buf[100];
 
 	static struct {
 		struct switchtec_dev *dev;
@@ -253,6 +306,12 @@ static int status(int argc, char **argv)
 		bw_val = switchtec_bwcntr_tot(&bw_data[p].ingress);
 		bw_suf = suffix_si_get(&bw_val);
 		printf("\tIn Bytes:        \t%-.3g %sB\n", bw_val, bw_suf);
+
+		if (s->acs_ctrl != -1) {
+			pci_acs_to_string(buf, sizeof(buf), s->acs_ctrl,
+					  cfg.verbose);
+			printf("\tACS:             \t%s\n", buf);
+		}
 
 		if (!s->vendor_id || !s->device_id || !s->pci_dev)
 			continue;

--- a/inc/switchtec/pci.h
+++ b/inc/switchtec/pci.h
@@ -1,0 +1,47 @@
+/*
+ * Microsemi Switchtec(tm) PCIe Management Library
+ * Copyright (c) 2018, Microsemi Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef LIBSWITCHTEC_PCI_H
+#define LIBSWITCHTEC_PCI_H
+
+#include <string.h>
+
+#define PCI_EXT_CAP_OFFSET 0x100
+#define PCI_EXT_CAP_ID(cap)((cap) & 0x0000ffff)
+#define PCI_EXT_CAP_VER(cap)(((cap) >> 16) & 0xf)
+#define PCI_EXT_CAP_NEXT(cap)(((cap) >> 20) & 0xffc)
+
+#define PCI_EXT_CAP_ID_ACS      0x0d
+
+#define PCI_ACS_CTRL            0x06    //!< ACS Control Register
+#define PCI_ACS_CTRL_VALID      0x0001  //!< ACS Source Validation Enable
+#define PCI_ACS_CTRL_BLOCK      0x0002  //!< ACS Translation Blocking Enable
+#define PCI_ACS_CTRL_REQ_RED    0x0004  //!< ACS P2P Request Redirect Enable
+#define PCI_ACS_CTRL_CMPLT_RED  0x0008  //!< ACS P2P Completion Redirect Enable
+#define PCI_ACS_CTRL_FORWARD    0x0010  //!< ACS Upstream Forwarding Enable
+#define PCI_ACS_CTRL_EGRESS     0x0020  //!< ACS P2P Egress Control Enable
+#define PCI_ACS_CTRL_TRANS      0x0040  //!< ACS Direct Translated P2P Enable
+#define PCI_ACS_EGRESS_CTRL     0x08    //!< Egress Control Vector
+
+#endif

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -115,6 +115,7 @@ struct switchtec_status {
 	int vendor_id;			//!< Vendor ID
 	int device_id;			//!< Device ID
 	char *class_devices;		//!< Comma seperated list of classes
+	unsigned int acs_ctrl;		//!< ACS Setting of the Port
 };
 
 /**

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -108,7 +108,9 @@ struct switchtec_status {
 	unsigned char ltssm;		//!< Link state
 	const char *ltssm_str;		//!< Link state as a string
 
-	char *pci_dev;			//!< PCI BDF of the port
+	char *pci_bdf;			//!< PCI BDF of the port
+
+	char *pci_dev;			//!< PCI BDF of the device on the port
 	int vendor_id;			//!< Vendor ID
 	int device_id;			//!< Device ID
 	char *class_devices;		//!< Comma seperated list of classes

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -109,6 +109,7 @@ struct switchtec_status {
 	const char *ltssm_str;		//!< Link state as a string
 
 	char *pci_bdf;			//!< PCI BDF of the port
+	char *pci_bdf_path;		//!< PCI BDF path of the port
 
 	char *pci_dev;			//!< PCI BDF of the device on the port
 	int vendor_id;			//!< Vendor ID

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -367,6 +367,9 @@ void switchtec_status_free(struct switchtec_status *status, int ports)
 	int i;
 
 	for (i = 0; i < ports; i++) {
+		if (status[i].pci_bdf)
+			free(status[i].pci_bdf);
+
 		if (status[i].pci_dev)
 			free(status[i].pci_dev);
 

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -348,6 +348,9 @@ int switchtec_status(struct switchtec_dev *dev,
 		s[p].link_rate = ports[i].linkup_linkrate & 0x7F;
 		s[p].ltssm = le16toh(ports[i].LTSSM);
 		s[p].ltssm_str = ltssm_str(s[i].ltssm, 0);
+
+		s[p].acs_ctrl = -1;
+
 		p++;
 	}
 

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -370,6 +370,9 @@ void switchtec_status_free(struct switchtec_status *status, int ports)
 		if (status[i].pci_bdf)
 			free(status[i].pci_bdf);
 
+		if (status[i].pci_bdf_path)
+			free(status[i].pci_bdf_path);
+
 		if (status[i].pci_dev)
 			free(status[i].pci_dev);
 


### PR DESCRIPTION
Hi,

For the P2P applications we are working on it is useful to quickly know the ACS status for all the dowstream ports (DSPs). We're also working on a [patchset](https://lkml.org/lkml/2018/6/27/536) for the Linux kernel to disable ACS for a set of DSPs using a command line parameter. For this, it is useful to know the BDF for the DSP that we need to disable ACS for. It's also recommended to use a BDF path to address a device which is more stable to renumbering concerns (see the Linux pathset for more information).

Patch 1 and 2 in this series add the port's BDF and BDF path to the status structure. Patch 3 prints this information in the 'switchtec status' command. Patch 4 and 5 are to parse the PCI configuration structure to obtain the ACS register for the port and the final patch prints that information in switchtec status.

This patchset passes Travis.

Thanks,

Logan


