### PR TITLE
Fix false alarming when fw toggle command

### DIFF
--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -61,7 +61,7 @@ struct switchtec_linux {
 
 const char *platform_strerror(void)
 {
-	return "Unknown Error";
+	return "Success";
 }
 
 static int dev_to_sysfs_path(struct switchtec_linux *ldev, const char *suffix,


### PR DESCRIPTION
Only output error message when fw toggle execution
failed case.
Before the fix, the output is "unknown error" when
success case.