### PR TITLE
Fix build regression in recent gui_main() change

### DIFF
--- a/cli/gui.c
+++ b/cli/gui.c
@@ -447,7 +447,7 @@ int gui_main(struct switchtec_dev *dev, unsigned all_ports, unsigned reset,
 #else
 
 int gui_main(struct switchtec_dev *dev, unsigned all_ports, unsigned reset,
-	     unsigned refresh, int duration)
+	     unsigned refresh, int duration, enum switchtec_bw_type bw_type)
 {
 	printf("gui requires libcurses support when switchtec-user is built\n");
 	return 0;

--- a/cli/gui.h
+++ b/cli/gui.h
@@ -27,7 +27,7 @@
 
 #include <switchtec/switchtec.h>
 
-int gui_main(struct switchtec_dev *, unsigned, unsigned, unsigned, int,
-	     enum switchtec_bw_type);
+int gui_main(struct switchtec_dev *dev, unsigned all_ports, unsigned reset,
+	     unsigned refresh, int duration, enum switchtec_bw_type bw_type);
 
 #endif


### PR DESCRIPTION
There are two gui_main() functions. When libcurses is not available
(ie. when cross compling for windows), a stub function is used.
A recent change to the gui_main() prototype forgot to make the
analagous change to the stub function and therefore caused
a build regression.

While we are at it fix, the function prototype in gui.h which should have
proper argument names.

This was caught by travis on the latest devel branch.

It would be nice if you can get continuous integration setup for your process so you can catch these errors much earlier in the development process.
