### PR TITLE
bugfix  - bandwidth incorrect 

### DIFF
--- a/cli/gui.c
+++ b/cli/gui.c
@@ -349,6 +349,9 @@ retry:
 	ret = switchtec_bwcntr_set_many(dev, numports, port_ids, bw_type);
 	if (ret < 0)
 		cleanup_and_error("Set bandwidth type");
+	/* switchtec_bwcntr_set_many will reset bandwidth counter and it needs
+	 * about 1s. */
+	sleep(1);
 
 	if (reset)
 		ret = switchtec_bwcntr_many(dev, numports, port_ids, 1, NULL);

--- a/cli/main.c
+++ b/cli/main.c
@@ -309,6 +309,9 @@ static int bw(int argc, char **argv)
 		switchtec_perror("bw type");
 		return ret;
 	}
+	/* switchtec_bwcntr_set_all will reset bandwidth counter and it needs
+	 * about 1s */
+	sleep(1);
 
 	ret = switchtec_bwcntr_all(cfg.dev, 0, &port_ids, &before);
 	if (ret < 0) {


### PR DESCRIPTION
Issue: The bw command does not report correct bandwidth data.

This issue is introduced by pull request #19 (Add payload bandwidth support on switchtec-user command gui and bw). 

The bandwidth counter would be reset in max 250ms after received the Set Bandwidth Counter MRPC command. To finish the bandwidth counter reset, a delay is needed before the Get Bandwidth Couner MRPC command.