### PR TITLE
set errno to 0 in "switchtec_open_by_path" for inband

### DIFF
--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -781,6 +781,8 @@ struct switchtec_dev *switchtec_open_by_path(const char *path)
 
 	if (isatty(fd))
 		return switchtec_open_uart(fd);
+	else
+		errno = 0;
 
 	ldev = malloc(sizeof(*ldev));
 	if (!ldev)


### PR DESCRIPTION
for fw-toggle and evcntr-setup command, the corresponding
function invoke "switchtec_perror" w/o ret value check, which
may lead to switchtec-user utility pop up false alarm, because
errno is no 0.