### PR TITLE
if errno not equal to 0, keep its value instead of set to ENODEV

### DIFF
--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -131,7 +131,7 @@ found:
 	if (ret)
 		snprintf(ret->name, sizeof(ret->name), "%s", device);
 	else
-		errno = ENODEV;
+		errno = errno ? errno : ENODEV;
 
 	return ret;
 }


### PR DESCRIPTION
In switchtec_open funcion, if no device was found, while errno equal
to 0, this will introduce false "success" prompt, so in this case,
set the errno to ENODEV unconditionly.

But if errno already set by system api, its value should be kept
instead of set to ENODEV.