### PR TITLE
Fix a bug in fw-toggle output

### DIFF
--- a/lib/platform/linux-i2c.c
+++ b/lib/platform/linux-i2c.c
@@ -504,6 +504,8 @@ static void i2c_gas_read(struct switchtec_dev *dev, void *dest,
 
 	if (retry_count == MAX_RETRY_COUNT)
 		raise(SIGBUS);
+
+	errno = 0;
 }
 
 static void i2c_memcpy_from_gas(struct switchtec_dev *dev, void *dest,


### PR DESCRIPTION
The fw-toggle command will show success or failure message by
switchtec_perror() at the end of output. switchtec_perror() takes errno
as the only input for message output.

It's possible that all the toggle operations was done successfully, but
the errno is not zero. Consider the case that a code snippet calls a
function with retries, and the first calls failed and errno set, then
one retry succeeded. In this case errno is set, and operations are
succeeded. The problem is the call to switchtec_perror() is
unconditional. This would result in the switchtec_perror() show failure
message on success.

This patch fix this by set correct errno before the call to
switchtec_perror().