### PR TITLE
In-band GAS read & GAS dump output sanity check

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -2016,7 +2016,6 @@ static struct prog_info prog_info = {
 		"(ex: /dev/switchtec0)",
 };
 
-#ifndef _WIN32
 static void sig_handler(int signum)
 {
 	if (signum == SIGBUS) {
@@ -2030,14 +2029,6 @@ static void setup_sigbus(void)
 {
 	signal(SIGBUS, sig_handler);
 }
-
-#else /* _WIN32 defined */
-
-static void setup_sigbus(void)
-{
-}
-
-#endif
 
 int main(int argc, char **argv)
 {

--- a/inc/switchtec/portable.h
+++ b/inc/switchtec/portable.h
@@ -56,6 +56,12 @@
 #endif
 #endif
 
+#ifdef __WINDOWS__
+#ifndef SIGBUS
+#define SIGBUS SIGABRT
+#endif
+#endif
+
 #ifdef __MINGW32__
 #define ffs __builtin_ffs
 #endif

--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -47,6 +47,16 @@
 #define gas_reg_write64(dev, val, reg) gas_write64(dev, val, \
 						   &dev->gas_map->reg)
 
+int gasop_access_check(struct switchtec_dev *dev)
+{
+	uint32_t device_id;
+
+	device_id = gas_reg_read32(dev, sys_info.device_id);
+	if (device_id == -1)
+		return -1;
+	return 0;
+}
+
 void gasop_set_partition_info(struct switchtec_dev *dev)
 {
 	dev->partition = gas_reg_read8(dev, top.partition_id);

--- a/lib/platform/gasops.h
+++ b/lib/platform/gasops.h
@@ -27,6 +27,7 @@
 
 #include "switchtec/switchtec.h"
 
+int gasop_access_check(struct switchtec_dev *dev);
 void gasop_set_partition_info(struct switchtec_dev *dev);
 int gasop_cmd(struct switchtec_dev *dev, uint32_t cmd,
 	      const void *payload, size_t payload_len, void *resp,

--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -30,6 +30,7 @@
 #include "switchtec/switchtec.h"
 #include "switchtec/pci.h"
 #include "mmap_gas.h"
+#include "gasops.h"
 
 #include <linux/switchtec_ioctl.h>
 
@@ -730,6 +731,11 @@ static gasptr_t linux_gas_map(struct switchtec_dev *dev, int writeable,
 	dev->gas_map = (gasptr_t __force)map;
 	dev->gas_map_size = msize;
 
+	ret = gasop_access_check(dev);
+	if (ret) {
+		errno = ENODEV;
+		goto unmap_and_exit;
+	}
 	return (gasptr_t __force)map;
 
 unmap_and_exit:

--- a/lib/platform/windows.c
+++ b/lib/platform/windows.c
@@ -409,9 +409,16 @@ static int windows_event_wait(struct switchtec_dev *dev, int timeout_ms)
 static gasptr_t windows_gas_map(struct switchtec_dev *dev, int writeable,
 				size_t *map_size)
 {
+	int ret;
+
 	if (map_size)
 		*map_size = dev->gas_map_size;
 
+	ret = gasop_access_check(dev);
+	if (ret) {
+		errno = ENODEV;
+		return SWITCHTEC_MAP_FAILED;
+	}
 	return dev->gas_map;
 }
 


### PR DESCRIPTION
To distinguish all 1 returns of in-band GAS read & GAS dump valid
or not, a light way rely on check of device id is added.
Raise the SIGABRT signal when the output is abnormal.

For the reason of Windows system has no define of SIGBUS in
SIGNAL.H, SIGABRT is choosed.