### PR TITLE
Fix unreadable output string for list command

### DIFF
--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -180,7 +180,7 @@ static void get_device_str(const char *path, const char *file,
 		 path, file);
 
 	ret = sysfs_read_str(sysfs_path, buf, buflen);
-	if (ret < 0)
+	if (ret < 0 || buf[0] == -1)
 		snprintf(buf, buflen, "unknown");
 
 	buf[strcspn(buf, "\n")] = 0;


### PR DESCRIPTION
In system broken state e.g., state after run hard-rest command, all
1 returns from GAS register read access lead to the unreadable
output string by list command.
Fix this issue by output "unknown" string in that case.

Windows platform has no of this issue, for the reason of the list
command fetch required info from registry instead of GAS registers.