### PR TITLE
Fix logical error when parse partition and port of event

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -709,7 +709,7 @@ static int event_wait(int argc, char **argv)
 	case SWITCHTEC_EVT_GLOBAL:
 		break;
 	case SWITCHTEC_EVT_PART:
-		if (cfg.port < 0) {
+		if (cfg.port >= 0) {
 			fprintf(stderr, "Port cannot be specified for this event type.\n");
 			return -1;
 		}


### PR DESCRIPTION
In event-wait function, there should be negtive value for port
when event type is SWITCHTEC_EVT_PART, which means port cannot
be specified for this event type.

Previsouly, the default port value (-1) will lead to error
return of this function.
Fix it by error return only when port is set a non-negtive
value.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>