### PR TITLE
Fix output of event-wait command with false info on Windows platform

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -669,7 +669,7 @@ static int event_wait(int argc, char **argv)
 {
 	const char *desc = "Wait for an event to occur";
 	struct event_list elist[256];
-	struct switchtec_event_summary sum;
+	struct switchtec_event_summary sum = {0};
 	struct argconfig_choice event_choices[SWITCHTEC_MAX_EVENTS + 1] = {};
 	int index = 0;
 	int ret;


### PR DESCRIPTION
On Windows platform, the output of event-wait command with false
info when timeout(command such as: switchtec.exe event-wait
switchtec0 -t 1000).
The root cause is: the data structure struct switchtec_event_summary
sum doesn't zeroize on Windows platform like Linux platform, and
in timeout situation, no update of this data structure, then
the output is false and random.
Fix it by zeroize the structure before use it.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>