### PR TITLE
Unify the output of event-wait command

### DIFF
--- a/lib/events.c
+++ b/lib/events.c
@@ -411,8 +411,10 @@ next:
 
 		now = ((tv.tv_sec) * 1000 + tv.tv_usec / 1000);
 
-		if (timeout_ms > 0 && now - start >= timeout_ms)
-			return 0;
+		if (timeout_ms > 0 && now - start >= timeout_ms) {
+			ret = switchtec_event_summary(dev, res);
+			return ret;
+		}
 	}
 }
 


### PR DESCRIPTION
The output of event-wait command is different between in-band
(Windows & Linux) and TWI/UART interfaces in case of timeout
& w/o any event happened, the former output nothing while the
latter print out the event summary.

The reason for this difference is because the event summary only
update when some event happened, but keep all zero when timeout
& w/o any event happened situation in in-band mode.

To unify the output for all interfaces, add code to retrieve the
event summary in case of timeout for in-band mode.

There are two cases of timeout:
a. timeout w/o any event happen
b. timeout w/ some event happened, but not the waited one
The code it redundant for case b

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>