### PR TITLE
Add event check for local partition

### DIFF
--- a/lib/events.c
+++ b/lib/events.c
@@ -316,6 +316,9 @@ int switchtec_event_check(struct switchtec_dev *dev,
 	if (chk->part_bitmap & res->part_bitmap)
 		return 1;
 
+	if (chk->local_part & res->local_part)
+		return 1;
+
 	for (i = 0; i < SWITCHTEC_MAX_PARTS; i++)
 		if (chk->part[i] & res->part[i])
 			return 1;


### PR DESCRIPTION
In switchtec_event_summary_set function, if index type is
SWITCHTEC_EVT_IDX_LOCAL, the waited event bit is set on
variable local_part but not on variable array part[] out
of event summary data structure.

But switchtec_event_check function only check whether the
specified event happened or not by compare variable array
part[].
So there exist one case, the wanted event on the local
partition happened, but finally timeout for waiting.

Fix this false timeout by add event check for local
partition.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>