### PR TITLE
Event wait type

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -685,6 +685,7 @@ static int event_wait(int argc, char **argv)
 		.partition = -1,
 		.port = -1,
 		.timeout = -1,
+		.event_id = -1,
 	};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
@@ -735,6 +736,9 @@ static int event_wait(int argc, char **argv)
 			}
 		}
 		break;
+	default:
+		fprintf(stderr, "Must specify event type.\n");
+		return -1;
 	}
 
 	ret = switchtec_event_wait_for(cfg.dev, cfg.event_id, index, &sum,

--- a/cli/main.c
+++ b/cli/main.c
@@ -734,6 +734,7 @@ static int event_wait(int argc, char **argv)
 				return ret;
 			}
 		}
+		break;
 	}
 
 	ret = switchtec_event_wait_for(cfg.dev, cfg.event_id, index, &sum,

--- a/lib/events.c
+++ b/lib/events.c
@@ -339,6 +339,9 @@ enum switchtec_event_type switchtec_event_info(enum switchtec_event_id e,
 					       const char **name,
 					       const char **desc)
 {
+	if (e <= SWITCHTEC_EVT_INVALID || e >= SWITCHTEC_MAX_EVENTS)
+		return -1;
+
 	if (name)
 		*name = events[e].short_name;
 


### PR DESCRIPTION
Set the default value of waited event id as -1(SWITCHTEC_EVT_INVALID)
and popup warning when user doesn't specify a valid event type
for event-wait command.
