### PR TITLE
Fix a typo in temp_lib.py code

### DIFF
--- a/examples/temp_lib.py
+++ b/examples/temp_lib.py
@@ -38,9 +38,9 @@ import struct
 import ctypes as c
 
 if os.name == 'nt':
-	swlib = c.cdll.LoadLibrary("libswitchtec.so")
-else:
 	swlib = c.cdll.LoadLibrary("switchtec.dll")
+else:
+	swlib = c.cdll.LoadLibrary("libswitchtec.so")
 
 swlib.switchtec_open.argtypes = [c.c_char_p]
 swlib.switchtec_open.restype = c.c_void_p


### PR DESCRIPTION
In Linux environment, the library should be libswitchtec.so

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>