### PR TITLE
Reset usage string in case of command belong to named subcommand

### DIFF
--- a/cli/argconfig.c
+++ b/cli/argconfig.c
@@ -61,6 +61,11 @@ void argconfig_append_usage(const char *str)
 		strlen(append_usage_str) - 1);
 }
 
+void argconfig_reset_usage(void)
+{
+	append_usage_str[0] = '\0';
+}
+
 void print_word_wrapped(const char *s, int indent, int start)
 {
 	const int width = 76;

--- a/cli/argconfig.h
+++ b/cli/argconfig.h
@@ -110,6 +110,7 @@ extern "C" {
 
 typedef void argconfig_help_func();
 void argconfig_append_usage(const char *str);
+void argconfig_reset_usage(void);
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
 		    const struct argconfig_options *options,
 		    void *config_out, size_t config_size);

--- a/cli/commands.c
+++ b/cli/commands.c
@@ -237,9 +237,10 @@ static int do_command(int argc, char **argv, struct subcommand *subcmd,
 	}
 
 	while (ext) {
-		if (!strcmp(cmd, ext->name))
+		if (!strcmp(cmd, ext->name)) {
+			argconfig_reset_usage();
 			return do_command(argc - 1, &argv[1], ext, prog_info);
-
+		}
 		ext = ext->next;
 	}
 


### PR DESCRIPTION
To avoid the content of usage string with double copies of
programe info(exe) and command(cmd), reset the usage string
in case of command bleong to named subcommand

The double copies of same string output is test with command:
./swtichtec gas read
the output is like:
Usage: ./switchtec gas./switchtec gas read <device> [OPTIONS]

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>