### PR TITLE
Change port bind info command to list all enabled physical ports

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -992,23 +992,28 @@ static int arbitration_set(int argc, char **argv)
 
 static void print_bind_info(struct switchtec_bind_status_out status)
 {
-	enum switchtec_bind_info_result result = status.bind_state & 0x0F;
-	int state = (status.bind_state & 0xF0) >> 4;
+	int i;
 
-	switch (result) {
-	case BIND_INFO_SUCCESS:
-		printf("bind state: %s\n", state ? "Bound" : "Unbound");
-		if(state)
-			printf("physical port %u bound to %u, partition %u\n",
-			       status.phys_port_id, status.log_port_id,
-			       status.par_id);
-		break;
-	case BIND_INFO_FAIL:
-		printf("bind_info: Fail\n");
-		break;
-	case BIND_INFO_IN_PROGRESS:
-		printf("bind_info: In Progress\n");
-		break;
+	for (i = 0; i < status.inf_cnt; i++) {
+		enum switchtec_bind_info_result result = status.port_info[i].bind_state & 0x0F;
+		int state = (status.port_info[i].bind_state & 0xF0) >> 4;
+
+		switch (result) {
+		case BIND_INFO_SUCCESS:
+			printf("bind state: %s\n", state ? "Bound" : "Unbound");
+			if (state)
+				printf("physical port %u bound to %u, partition %u\n",
+				       status.port_info[i].phys_port_id,
+				       status.port_info[i].log_port_id,
+				       status.port_info[i].par_id);
+			break;
+		case BIND_INFO_FAIL:
+			printf("bind_info: Fail\n");
+			break;
+		case BIND_INFO_IN_PROGRESS:
+			printf("bind_info: In Progress\n");
+			break;
+		}
 	}
 }
 
@@ -1029,7 +1034,10 @@ static int port_bind_info(int argc, char **argv)
 
 	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
 
-	printf("physical port:%d\n", cfg.phy_port);
+	if (cfg.phy_port == 0xff)
+		printf("physical port: all\n");
+	else
+		printf("physical port: %d\n", cfg.phy_port);
 
 	ret = switchtec_bind_info(cfg.dev, &bind_status, cfg.phy_port);
 

--- a/inc/switchtec/bind.h
+++ b/inc/switchtec/bind.h
@@ -28,6 +28,8 @@
 #include <stdint.h>
 #include <switchtec/switchtec.h>
 
+#define SWITCHTEC_MAX_PHY_PORTS 48
+
 #pragma pack(push, 1)
 
 enum switchtec_bind_info_result {
@@ -48,10 +50,12 @@ struct switchtec_bind_status_out {
 	uint8_t reserved1;
 	uint8_t reserved2;
 	uint8_t reserved3;
-	uint8_t phys_port_id;
-	uint8_t par_id;
-	uint8_t log_port_id;
-	uint8_t bind_state;
+	struct {
+		uint8_t phys_port_id;
+		uint8_t par_id;
+		uint8_t log_port_id;
+		uint8_t bind_state;
+	} port_info[SWITCHTEC_MAX_PHY_PORTS];
 };
 
 struct switchtec_bind_in {


### PR DESCRIPTION
If Port Binding Info command input data with physical port ID equal
to 0xff, then the status of all the enabled physical ports will be
queried.
Changed the code accordingly.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>