### PR TITLE
Threshold of event counter usage rule rectify

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1798,8 +1798,8 @@ static int evcntr_setup(int argc, char **argv)
 	}
 
 	if (cfg.setup.threshold &&
-	    __builtin_popcount(cfg.setup.port_mask) > 1 &&
-	    __builtin_popcount(cfg.setup.type_mask) > 1)
+	    (__builtin_popcount(cfg.setup.port_mask) > 1 ||
+	    __builtin_popcount(cfg.setup.type_mask) > 1))
 	{
 		fprintf(stderr, "A threshold can only be used with a counter "
 			"that has a single port and single event\n");


### PR DESCRIPTION
Per dev spec: When the counter reaches threshold, a per-port event
notification is reported to the host. Note that only single valid
bit port mask and single valid bit event type mask counter are
able to perform event notification.
Change the 'and' operater to 'or'.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>