### PR TITLE
Enable showing of ltssm.minor status

### DIFF
--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -110,7 +110,7 @@ struct switchtec_status {
 	unsigned char neg_lnk_width;	//!< Negotiated link width
 	unsigned char link_up;		//!< 1 if the link is up
 	unsigned char link_rate;	//!< Link rate/gen
-	unsigned char ltssm;		//!< Link state
+	uint16_t ltssm;			//!< Link state
 	const char *ltssm_str;		//!< Link state as a string
 
 	char *pci_bdf;			//!< PCI BDF of the port

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -348,7 +348,7 @@ int switchtec_status(struct switchtec_dev *dev,
 		s[p].link_up = ports[i].linkup_linkrate >> 7;
 		s[p].link_rate = ports[i].linkup_linkrate & 0x7F;
 		s[p].ltssm = le16toh(ports[i].LTSSM);
-		s[p].ltssm_str = ltssm_str(s[i].ltssm, 0);
+		s[p].ltssm_str = ltssm_str(s[i].ltssm, 1);
 
 		s[p].acs_ctrl = -1;
 


### PR DESCRIPTION
The proposed pull contains two parts:
The update switchtec.h is the bug fix.
The update switchtec.c is optional.
Thanks,
Jason