### PR TITLE
Fall back to resource0 in case resource0_wc doesn't exist

### DIFF
--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -715,8 +715,13 @@ static gasptr_t linux_gas_map(struct switchtec_dev *dev, int writeable,
 
 	ret = mmap_resource(ldev, "device/resource0_wc", map, 0,
 			    SWITCHTEC_GAS_TOP_CFG_OFFSET, writeable);
-	if (ret)
-		goto unmap_and_exit;
+	if (ret) {
+		ret = mmap_resource(ldev, "device/resource0", map, 0,
+				    SWITCHTEC_GAS_TOP_CFG_OFFSET,
+				    writeable);
+		if (ret)
+			goto unmap_and_exit;
+	}
 
 	ret = mmap_resource(ldev, "device/resource0",
 			    map + SWITCHTEC_GAS_TOP_CFG_OFFSET,


### PR DESCRIPTION
If management/nt ep BAR is non-prefetchable, there will be no
resource0_wc device file exists under /sys/devices.
In this case, we fall back to resource0.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>