### PR TITLE
Display the physical port when list all port informaion

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1006,12 +1006,19 @@ static void print_bind_info(struct switchtec_bind_status_out status)
 				       status.port_info[i].phys_port_id,
 				       status.port_info[i].log_port_id,
 				       status.port_info[i].par_id);
+			else
+				printf("physical port %u\n",
+				       status.port_info[i].phys_port_id);
 			break;
 		case BIND_INFO_FAIL:
 			printf("bind_info: Fail\n");
+			printf("physical port %u\n",
+			       status.port_info[i].phys_port_id);
 			break;
 		case BIND_INFO_IN_PROGRESS:
 			printf("bind_info: In Progress\n");
+			printf("physical port %u\n",
+			       status.port_info[i].phys_port_id);
 			break;
 		}
 	}
@@ -1038,8 +1045,6 @@ static int port_bind_info(int argc, char **argv)
 
 	if (cfg.phy_port == 0xff)
 		printf("physical port: all\n");
-	else
-		printf("physical port: %d\n", cfg.phy_port);
 
 	ret = switchtec_bind_info(cfg.dev, &bind_status, cfg.phy_port);
 


### PR DESCRIPTION
When port state in unbound, bind fail, bind in progress, the physical
port information displayed when specify for a single port, but doesn't
appear when list all port information.

Fix this bug by display physical port in all the port states.

Signed-off-by: Wesley Sheng <wesley.sheng@microchip.com>