### PR TITLE
Enhance switchtec error handling to make it MRPC aware

### DIFF
--- a/inc/switchtec/errors.h
+++ b/inc/switchtec/errors.h
@@ -25,6 +25,9 @@
 #ifndef LIBSWITCHTEC_ERRORS_H
 #define LIBSWITCHTEC_ERRORS_H
 
+extern int mrpc_error_cmd;
+
+#define SWITCHTEC_ERRNO_MRPC_FLAG_BIT (1 << 30)
 
 enum {
 	ERR_PHYC_PORT_ARDY_BIND = 0x00000001,

--- a/lib/platform/platform.c
+++ b/lib/platform/platform.c
@@ -30,6 +30,7 @@
 #include "../switchtec_priv.h"
 #include "switchtec/switchtec.h"
 #include "switchtec/gas.h"
+#include "switchtec/errors.h"
 
 #include <errno.h>
 
@@ -131,7 +132,15 @@ int switchtec_cmd(struct switchtec_dev *dev,  uint32_t cmd,
 		  const void *payload, size_t payload_len, void *resp,
 		  size_t resp_len)
 {
-	return dev->ops->cmd(dev, cmd, payload, payload_len, resp, resp_len);
+	int ret;
+
+	ret = dev->ops->cmd(dev, cmd, payload, payload_len, resp, resp_len);
+	if (ret) {
+		mrpc_error_cmd = cmd;
+		errno |= SWITCHTEC_ERRNO_MRPC_FLAG_BIT;
+	}
+
+	return ret;
 }
 
 /**


### PR DESCRIPTION
A new global variable mprc was introduced for this. On MRPC handling
errors, this variable is set to the corresponding MRPC CMD ID, on other
errors, this variable is set to -1.