### PR TITLE
Replace several argument type from int to the correct one

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1037,7 +1037,7 @@ static int port_bind_info(int argc, char **argv)
 	};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
-		{"physical", 'f', "", CFG_INT, &cfg.phy_port, required_argument,
+		{"physical", 'f', "", CFG_NONNEGATIVE, &cfg.phy_port, required_argument,
 			"physical port number"},
 		{NULL}};
 
@@ -1069,11 +1069,11 @@ static int port_bind(int argc, char **argv)
 	} cfg = {};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
-		{"partition", 'p', "", CFG_INT, &cfg.par_id, required_argument,
+		{"partition", 'p', "", CFG_NONNEGATIVE, &cfg.par_id, required_argument,
 			"partition number"},
-		{"logical", 'l', "", CFG_INT, &cfg.log_port, required_argument,
+		{"logical", 'l', "", CFG_POSITIVE, &cfg.log_port, required_argument,
 			"logical port number"},
-		{"physical", 'f', "", CFG_INT, &cfg.phy_port, required_argument,
+		{"physical", 'f', "", CFG_NONNEGATIVE, &cfg.phy_port, required_argument,
 			"physical port number"},
 		{NULL}};
 
@@ -1100,9 +1100,9 @@ static int port_unbind(int argc, char **argv)
 	} cfg = {};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
-		{"partition", 'p', "", CFG_INT, &cfg.par_id, required_argument,
+		{"partition", 'p', "", CFG_NONNEGATIVE, &cfg.par_id, required_argument,
 			"partition number"},
-		{"logical", 'l', "", CFG_INT, &cfg.log_port, required_argument,
+		{"logical", 'l', "", CFG_POSITIVE, &cfg.log_port, required_argument,
 			"logical port number"},
 		{NULL}};
 


### PR DESCRIPTION
For port-bind/unbind/bind-info commands, their arguments, such
as physical port (0 to 47), partition (0 to number of partitions -1),
logical port (1 to number of down stream port) number should be
nonnegative, nonnegative and positive. Change current CFG_INT type
to corresponding type accordingly.

Signed-off-by: wesley sheng <wesley.sheng@microchip.com>