### PR TITLE
Introduce GAS access APIs that support fabric

### DIFF
--- a/inc/switchtec/mrpc.h
+++ b/inc/switchtec/mrpc.h
@@ -60,7 +60,10 @@ enum mrpc_cmd {
 	MRPC_MULTI_CFG = 29,
 	MRPC_SES = 30,
 	MRPC_RD_FLASH = 31,
+	MRPC_GAS_READ = 41,
 	MRPC_ECHO = 65,
+
+	MRPC_GAS_WRITE = 0x87,		//Check me, will update
 };
 
 enum mrpc_bg_status {

--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -51,7 +51,7 @@ int gasop_access_check(struct switchtec_dev *dev)
 {
 	uint32_t device_id;
 
-	device_id = gas_reg_read32(dev, sys_info.device_id);
+	device_id = __gas_read32(dev, &dev->gas_map->sys_info.device_id);
 	if (device_id == -1)
 		return -1;
 	return 0;
@@ -71,13 +71,13 @@ int gasop_cmd(struct switchtec_dev *dev, uint32_t cmd,
 	int status;
 	int ret;
 
-	memcpy_to_gas(dev, &mrpc->input_data, payload, payload_len);
+	__memcpy_to_gas(dev, &mrpc->input_data, payload, payload_len);
 	gas_write32(dev, cmd, &mrpc->cmd);
 
 	while (1) {
 		usleep(5000);
 
-		status = gas_read32(dev, &mrpc->status);
+		status = __gas_read32(dev, &mrpc->status);
 		if (status != SWITCHTEC_MRPC_STATUS_INPROGRESS)
 			break;
 	}
@@ -92,12 +92,12 @@ int gasop_cmd(struct switchtec_dev *dev, uint32_t cmd,
 		return -errno;
 	}
 
-	ret = gas_read32(dev, &mrpc->ret_value);
+	ret = __gas_read32(dev, &mrpc->ret_value);
 	if (ret)
 		errno = ret;
 
 	if(resp)
-		memcpy_from_gas(dev, resp, &mrpc->output_data, resp_len);
+		__memcpy_from_gas(dev, resp, &mrpc->output_data, resp_len);
 
 	return ret;
 }

--- a/lib/switchtec_priv.h
+++ b/lib/switchtec_priv.h
@@ -114,4 +114,70 @@ static inline void version_to_string(uint32_t version, char *buf, size_t buflen)
 
 const char *platform_strerror();
 
+static inline uint8_t __gas_read8(struct switchtec_dev *dev,
+				  uint8_t __gas *addr)
+{
+	return dev->ops->gas_read8(dev, addr);
+}
+
+static inline uint16_t __gas_read16(struct switchtec_dev *dev,
+				    uint16_t __gas *addr)
+{
+	return dev->ops->gas_read16(dev, addr);
+}
+
+static inline uint32_t __gas_read32(struct switchtec_dev *dev,
+				    uint32_t __gas *addr)
+{
+	return dev->ops->gas_read32(dev, addr);
+}
+
+static inline uint64_t __gas_read64(struct switchtec_dev *dev,
+				    uint64_t __gas *addr)
+{
+	return dev->ops->gas_read64(dev, addr);
+}
+
+static inline void __gas_write8(struct switchtec_dev *dev, uint8_t val,
+				uint8_t __gas *addr)
+{
+	dev->ops->gas_write8(dev, val, addr);
+}
+
+static inline void __gas_write16(struct switchtec_dev *dev, uint16_t val,
+				 uint16_t __gas *addr)
+{
+	dev->ops->gas_write16(dev, val, addr);
+}
+
+static inline void __gas_write32(struct switchtec_dev *dev, uint32_t val,
+				 uint32_t __gas *addr)
+{
+	dev->ops->gas_write32(dev, val, addr);
+}
+
+static inline void __gas_write64(struct switchtec_dev *dev, uint64_t val,
+				 uint64_t __gas *addr)
+{
+	dev->ops->gas_write64(dev, val, addr);
+}
+
+static inline void __memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
+				   const void *src, size_t n)
+{
+	dev->ops->memcpy_to_gas(dev, dest, src, n);
+}
+
+static inline void __memcpy_from_gas(struct switchtec_dev *dev, void *dest,
+				     const void __gas *src, size_t n)
+{
+	dev->ops->memcpy_from_gas(dev, dest, src, n);
+}
+
+static inline ssize_t __write_from_gas(struct switchtec_dev *dev, int fd,
+				       const void __gas *src, size_t n)
+{
+	return dev->ops->write_from_gas(dev, fd, src, n);
+}
+
 #endif


### PR DESCRIPTION
The original GAS access APIs only supports local Switchtec
devices. This patch add new APIs to support both remote and local
GAS access, by leveraging the GAS READ/WRITE MRPC commands.

Note: The subcommand will be changed in Gen4 F/W, need update later.