### PR TITLE
Fix a bug with mrpc_errno_cmd

### DIFF
--- a/lib/platform/platform.c
+++ b/lib/platform/platform.c
@@ -139,7 +139,7 @@ int switchtec_cmd(struct switchtec_dev *dev,  uint32_t cmd,
 
 	ret = dev->ops->cmd(dev, cmd, payload, payload_len, resp, resp_len);
 	if (ret) {
-		mrpc_error_cmd = cmd;
+		mrpc_error_cmd = cmd & SWITCHTEC_CMD_MASK;
 		errno |= SWITCHTEC_ERRNO_MRPC_FLAG_BIT;
 	}
 


### PR DESCRIPTION
The high bits of mrpc_errno_cmd need to be cleared to ensure it
is not encoded with PAX id.