### PR TITLE
Fix an output alignment issue with command list

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -132,7 +132,7 @@ static int list(int argc, char **argv)
 		return n;
 
 	for (i = 0; i < n; i++) {
-		printf("%-20s\t%-15s\t%-5s\t%-10s\t%s\n", devices[i].name,
+		printf("%-20s\t%-16s%-5s\t%-10s\t%s\n", devices[i].name,
 		       devices[i].product_id, devices[i].product_rev,
 		       devices[i].fw_version, devices[i].pci_dev);
 		if (cfg.verbose) {


### PR DESCRIPTION
Gen4 device name maybe one character longer than Gen3, which makes the output unaligned. 
```
switchtec0              PSX 96XG3       RevB    1.0b B080       0000:81:00.1
switchtec1              PSX 96XG3       RevB    2.06 B032       0000:86:00.1
switchtec2              PFX 100XG4              00      3.30 B026       0000:8c:00.1
switchtec3              PAX 52XG4               00      4.30 B007       0000:90:00.1
```
Updated output looks like below.
```
switchtec0              PSX 96XG3       RevB    1.0b B080       0000:81:00.1
switchtec1              PSX 96XG3       RevB    2.06 B032       0000:86:00.1
switchtec2              PFX 100XG4      00      3.30 B026       0000:8c:00.1
switchtec3              PAX 52XG4       00      4.30 B007       0000:90:00.1
```