### PR TITLE
Mrpc gas x2

### DIFF
--- a/inc/switchtec/gas_mrpc.h
+++ b/inc/switchtec/gas_mrpc.h
@@ -1,0 +1,79 @@
+/*
+ * Microsemi Switchtec(tm) PCIe Management Library
+ * Copyright (c) 2019, Microsemi Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef LIBSWITCHTEC_GAS_MRPC_H
+#define LIBSWITCHTEC_GAS_MRPC_H
+
+#include <switchtec/mrpc.h>
+#include <switchtec/switchtec.h>
+#include <stdint.h>
+
+struct gas_mrpc_write {
+	uint32_t gas_offset;
+	uint32_t len;
+	uint8_t data[MRPC_MAX_DATA_LEN - 2 * sizeof(uint32_t)];
+};
+
+struct gas_mrpc_read {
+	uint32_t gas_offset;
+	uint32_t len;
+};
+
+void gas_mrpc_memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
+			    const void *src, size_t n);
+void gas_mrpc_memcpy_from_gas(struct switchtec_dev *dev, void *dest,
+			      const void __gas *src, size_t n);
+ssize_t gas_mrpc_write_from_gas(struct switchtec_dev *dev, int fd,
+				const void __gas *src, size_t n);
+
+#define create_mrpc_gas_read(type, suffix) \
+	static inline type gas_mrpc_read ## suffix(struct switchtec_dev *dev, \
+						   type __gas *addr) \
+	{ \
+		type ret; \
+		gas_mrpc_memcpy_from_gas(dev, &ret, addr, sizeof(ret)); \
+		return ret; \
+	}
+
+#define create_mrpc_gas_write(type, suffix) \
+	static inline void gas_mrpc_write ## suffix(struct switchtec_dev *dev, \
+			type val, type __gas *addr) \
+	{ \
+		gas_mrpc_memcpy_to_gas(dev, addr, &val, sizeof(val)); \
+	}
+
+create_mrpc_gas_read(uint8_t, 8);
+create_mrpc_gas_read(uint16_t, 16);
+create_mrpc_gas_read(uint32_t, 32);
+create_mrpc_gas_read(uint64_t, 64);
+
+create_mrpc_gas_write(uint8_t, 8);
+create_mrpc_gas_write(uint16_t, 16);
+create_mrpc_gas_write(uint32_t, 32);
+create_mrpc_gas_write(uint64_t, 64);
+
+#undef create_mrpc_gas_read
+#undef create_mrpc_gas_write
+
+#endif

--- a/inc/switchtec/mrpc.h
+++ b/inc/switchtec/mrpc.h
@@ -60,6 +60,8 @@ enum mrpc_cmd {
 	MRPC_MULTI_CFG = 29,
 	MRPC_SES = 30,
 	MRPC_RD_FLASH = 31,
+	MRPC_GAS_READ = 41,
+	MRPC_GAS_WRITE = 52,
 	MRPC_ECHO = 65,
 	MRPC_GET_PAX_ID = 129,
 };

--- a/inc/switchtec/mrpc.h
+++ b/inc/switchtec/mrpc.h
@@ -61,6 +61,7 @@ enum mrpc_cmd {
 	MRPC_SES = 30,
 	MRPC_RD_FLASH = 31,
 	MRPC_ECHO = 65,
+	MRPC_GET_PAX_ID = 129,
 };
 
 enum mrpc_bg_status {

--- a/lib/gas_mrpc.c
+++ b/lib/gas_mrpc.c
@@ -1,0 +1,145 @@
+/*
+ * Microsemi Switchtec(tm) PCIe Management Library
+ * Copyright (c) 2017, Microsemi Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include "switchtec/gas_mrpc.h"
+#include "switchtec/switchtec.h"
+#include "switchtec_priv.h"
+
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+
+/**
+ * @defgroup GAS Access through MRPC commands
+ * @brief Access the GAS through MRPC commands
+ *
+ * Access the gas through MRPC commands. The linux kernel may reject
+ * these commands if the process has insufficient permission.
+ *
+ * MRPC commands respect the PAX ID where as standard gas access mechanisms
+ * may not.
+ *
+ * These functions should generally not be used unless you really know what
+ * you are doing.
+ *
+ * @{
+ */
+
+/**
+ * @brief Copy data to the GAS using MRPC commands
+ * @param[in]  dev	Switchtec device handle
+ * @param[out] dest	Destination gas address
+ * @param[in]  src	Source data buffer
+ * @param[in]  n	Number of bytes to transfer
+ */
+void gas_mrpc_memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
+			    const void *src, size_t n)
+{
+	struct gas_mrpc_write cmd;
+	int ret;
+
+	cmd.gas_offset = (uint32_t)(dest - (void __gas *)dev->gas_map);
+
+	while (n) {
+		cmd.len = n;
+		if (cmd.len > sizeof(cmd.data))
+			cmd.len = sizeof(cmd.data);
+
+		memcpy(&cmd.data, src, cmd.len);
+
+		ret = switchtec_cmd(dev, MRPC_GAS_WRITE, &cmd,
+				    cmd.len + sizeof(cmd) - sizeof(cmd.data),
+				    NULL, 0);
+		if (ret)
+			raise(SIGBUS);
+
+		n -= cmd.len;
+		cmd.gas_offset += cmd.len;
+	}
+}
+
+/**
+ * @brief Copy data from the GAS using MRPC commands
+ * @param[in]  dev	Switchtec device handle
+ * @param[out] dest	Destination buffer
+ * @param[in]  src	Source gas address
+ * @param[in]  n	Number of bytes to transfer
+ */
+void gas_mrpc_memcpy_from_gas(struct switchtec_dev *dev, void *dest,
+			      const void __gas *src, size_t n)
+{
+	struct gas_mrpc_read cmd;
+	int ret;
+
+	cmd.gas_offset = (uint32_t)(src - (void __gas *)dev->gas_map);
+
+	while (n) {
+		cmd.len = n;
+		if (cmd.len > MRPC_MAX_DATA_LEN)
+			cmd.len = MRPC_MAX_DATA_LEN;
+
+		ret = switchtec_cmd(dev, MRPC_GAS_READ, &cmd,
+				    sizeof(cmd), dest, cmd.len);
+		if (ret)
+			raise(SIGBUS);
+
+		n -= cmd.len;
+		dest += cmd.len;
+	}
+}
+
+/**
+ * @brief Call write() with data from the GAS using an MRPC command
+ * @param[in] dev	Switchtec device handle
+ * @param[in] fd	Destination buffer
+ * @param[in] src	Source gas address
+ * @param[in] n		Number of bytes to transfer
+ */
+ssize_t gas_mrpc_write_from_gas(struct switchtec_dev *dev, int fd,
+				const void __gas *src, size_t n)
+{
+	char buf[MRPC_MAX_DATA_LEN];
+	ssize_t ret, total = 0;
+	size_t txfr_sz;
+
+	while (n) {
+		txfr_sz = n;
+		if (txfr_sz > sizeof(buf))
+			txfr_sz = sizeof(buf);
+
+		gas_mrpc_memcpy_from_gas(dev, buf, src, txfr_sz);
+
+		ret = write(fd, buf, txfr_sz);
+		if (ret < 0)
+			return ret;
+
+		n -= ret;
+		src += ret;
+		total += ret;
+	}
+
+	return total;
+}
+
+/**@}*/

--- a/lib/gas_mrpc.c
+++ b/lib/gas_mrpc.c
@@ -41,7 +41,8 @@
  * may not.
  *
  * These functions should generally not be used unless you really know what
- * you are doing.
+ * you are doing. The regular gas accessors (ie. gas_*()) will call these
+ * functions when switchtec_set_pax_id() has been used.
  *
  * @{
  */

--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -33,19 +33,19 @@
 #include <unistd.h>
 #include <sys/time.h>
 
-#define gas_reg_read8(dev, reg)  gas_read8(dev, &dev->gas_map->reg)
-#define gas_reg_read16(dev, reg) gas_read16(dev, &dev->gas_map->reg)
-#define gas_reg_read32(dev, reg) gas_read32(dev, &dev->gas_map->reg)
-#define gas_reg_read64(dev, reg) gas_read64(dev, &dev->gas_map->reg)
+#define gas_reg_read8(dev, reg)  __gas_read8(dev, &dev->gas_map->reg)
+#define gas_reg_read16(dev, reg) __gas_read16(dev, &dev->gas_map->reg)
+#define gas_reg_read32(dev, reg) __gas_read32(dev, &dev->gas_map->reg)
+#define gas_reg_read64(dev, reg) __gas_read64(dev, &dev->gas_map->reg)
 
-#define gas_reg_write8(dev, val, reg)  gas_write8(dev, val, \
-						  &dev->gas_map->reg)
-#define gas_reg_write16(dev, val, reg) gas_write16(dev, val, \
-						   &dev->gas_map->reg)
-#define gas_reg_write32(dev, val, reg) gas_write32(dev, val, \
-						   &dev->gas_map->reg)
-#define gas_reg_write64(dev, val, reg) gas_write64(dev, val, \
-						   &dev->gas_map->reg)
+#define gas_reg_write8(dev, val, reg)  __gas_write8(dev, val, \
+						    &dev->gas_map->reg)
+#define gas_reg_write16(dev, val, reg) __gas_write16(dev, val, \
+						     &dev->gas_map->reg)
+#define gas_reg_write32(dev, val, reg) __gas_write32(dev, val, \
+						     &dev->gas_map->reg)
+#define gas_reg_write64(dev, val, reg) __gas_write64(dev, val, \
+						     &dev->gas_map->reg)
 
 int gasop_access_check(struct switchtec_dev *dev)
 {
@@ -71,13 +71,13 @@ int gasop_cmd(struct switchtec_dev *dev, uint32_t cmd,
 	int status;
 	int ret;
 
-	memcpy_to_gas(dev, &mrpc->input_data, payload, payload_len);
-	gas_write32(dev, cmd, &mrpc->cmd);
+	__memcpy_to_gas(dev, &mrpc->input_data, payload, payload_len);
+	__gas_write32(dev, cmd, &mrpc->cmd);
 
 	while (1) {
 		usleep(5000);
 
-		status = gas_read32(dev, &mrpc->status);
+		status = __gas_read32(dev, &mrpc->status);
 		if (status != SWITCHTEC_MRPC_STATUS_INPROGRESS)
 			break;
 	}
@@ -92,12 +92,12 @@ int gasop_cmd(struct switchtec_dev *dev, uint32_t cmd,
 		return -errno;
 	}
 
-	ret = gas_read32(dev, &mrpc->ret_value);
+	ret = __gas_read32(dev, &mrpc->ret_value);
 	if (ret)
 		errno = ret;
 
 	if(resp)
-		memcpy_from_gas(dev, resp, &mrpc->output_data, resp_len);
+		__memcpy_from_gas(dev, resp, &mrpc->output_data, resp_len);
 
 	return ret;
 }
@@ -131,20 +131,20 @@ int gasop_pff_to_port(struct switchtec_dev *dev, int pff,
 		pcfg = &dev->gas_map->part_cfg[part];
 		*partition = part;
 
-		reg = gas_read32(dev, &pcfg->usp_pff_inst_id);
+		reg = __gas_read32(dev, &pcfg->usp_pff_inst_id);
 		if (reg == pff) {
 			*port = 0;
 			return 0;
 		}
 
-		reg = gas_read32(dev, &pcfg->vep_pff_inst_id);
+		reg = __gas_read32(dev, &pcfg->vep_pff_inst_id);
 		if (reg == pff) {
 			*port = SWITCHTEC_PFF_PORT_VEP;
 			return 0;
 		}
 
 		for (i = 0; i < ARRAY_SIZE(pcfg->dsp_pff_inst_id); i++) {
-			reg = gas_read32(dev, &pcfg->dsp_pff_inst_id[i]);
+			reg = __gas_read32(dev, &pcfg->dsp_pff_inst_id[i]);
 			if (reg != pff)
 				continue;
 
@@ -176,10 +176,10 @@ int gasop_port_to_pff(struct switchtec_dev *dev, int partition,
 
 	switch (port) {
 	case 0:
-		*pff = gas_read32(dev, &pcfg->usp_pff_inst_id);
+		*pff = __gas_read32(dev, &pcfg->usp_pff_inst_id);
 		break;
 	case SWITCHTEC_PFF_PORT_VEP:
-		*pff = gas_read32(dev, &pcfg->vep_pff_inst_id);
+		*pff = __gas_read32(dev, &pcfg->vep_pff_inst_id);
 		break;
 	default:
 		if (port > ARRAY_SIZE(pcfg->dsp_pff_inst_id)) {
@@ -187,7 +187,7 @@ int gasop_port_to_pff(struct switchtec_dev *dev, int partition,
 			return -errno;
 		}
 
-		*pff = gas_read32(dev, &pcfg->dsp_pff_inst_id[port - 1]);
+		*pff = __gas_read32(dev, &pcfg->dsp_pff_inst_id[port - 1]);
 		break;
 	}
 
@@ -198,8 +198,8 @@ static void set_fw_info_part(struct switchtec_dev *dev,
 			     struct switchtec_fw_image_info *info,
 			     struct partition_info __gas *pi)
 {
-	info->image_addr = gas_read32(dev, &pi->address);
-	info->image_len = gas_read32(dev, &pi->length);
+	info->image_addr = __gas_read32(dev, &pi->address);
+	info->image_len = __gas_read32(dev, &pi->length);
 }
 
 int gasop_flash_part(struct switchtec_dev *dev,
@@ -215,37 +215,37 @@ int gasop_flash_part(struct switchtec_dev *dev,
 
 	switch (part) {
 	case SWITCHTEC_FW_TYPE_IMG0:
-		active_addr = gas_read32(dev, &fi->active_img.address);
+		active_addr = __gas_read32(dev, &fi->active_img.address);
 		set_fw_info_part(dev, info, &fi->img0);
 
-		val = gas_read16(dev, &si->img_running);
+		val = __gas_read16(dev, &si->img_running);
 		if (val == SWITCHTEC_IMG0_RUNNING)
 			info->active |= SWITCHTEC_FW_PART_RUNNING;
 		break;
 
 	case SWITCHTEC_FW_TYPE_IMG1:
-		active_addr = gas_read32(dev, &fi->active_img.address);
+		active_addr = __gas_read32(dev, &fi->active_img.address);
 		set_fw_info_part(dev, info, &fi->img1);
 
-		val = gas_read16(dev, &si->img_running);
+		val = __gas_read16(dev, &si->img_running);
 		if (val == SWITCHTEC_IMG1_RUNNING)
 			info->active |= SWITCHTEC_FW_PART_RUNNING;
 		break;
 
 	case SWITCHTEC_FW_TYPE_DAT0:
-		active_addr = gas_read32(dev, &fi->active_cfg.address);
+		active_addr = __gas_read32(dev, &fi->active_cfg.address);
 		set_fw_info_part(dev, info, &fi->cfg0);
 
-		val = gas_read16(dev, &si->cfg_running);
+		val = __gas_read16(dev, &si->cfg_running);
 		if (val == SWITCHTEC_CFG0_RUNNING)
 			info->active |= SWITCHTEC_FW_PART_RUNNING;
 		break;
 
 	case SWITCHTEC_FW_TYPE_DAT1:
-		active_addr = gas_read32(dev, &fi->active_cfg.address);
+		active_addr = __gas_read32(dev, &fi->active_cfg.address);
 		set_fw_info_part(dev, info, &fi->cfg1);
 
-		val = gas_read16(dev, &si->cfg_running);
+		val = __gas_read16(dev, &si->cfg_running);
 		if (val == SWITCHTEC_CFG1_RUNNING)
 			info->active |= SWITCHTEC_FW_PART_RUNNING;
 		break;
@@ -393,10 +393,10 @@ static int event_ctl(struct switchtec_dev *dev, enum switchtec_event_id e,
 		return -errno;
 	}
 
-	hdr = gas_read32(dev, reg);
+	hdr = __gas_read32(dev, reg);
 	if (data)
 		for (i = 0; i < 5; i++)
-			data[i] = gas_read32(dev, &reg[i + 1]);
+			data[i] = __gas_read32(dev, &reg[i + 1]);
 
 	if (!(flags & SWITCHTEC_EVT_FLAG_CLEAR))
 		hdr &= ~SWITCHTEC_EVENT_CLEAR;
@@ -418,7 +418,7 @@ static int event_ctl(struct switchtec_dev *dev, enum switchtec_event_id e,
 		hdr &= ~SWITCHTEC_EVENT_FATAL;
 
 	if (flags)
-		gas_write32(dev, hdr, reg);
+		__gas_write32(dev, hdr, reg);
 
 	return (hdr >> 5) & 0xFF;
 }

--- a/lib/platform/platform.c
+++ b/lib/platform/platform.c
@@ -311,7 +311,7 @@ int switchtec_event_wait(struct switchtec_dev *dev, int timeout_ms)
  */
 uint8_t gas_read8(struct switchtec_dev *dev, uint8_t __gas *addr)
 {
-	return dev->ops->gas_read8(dev, addr);
+	return __gas_read8(dev, addr);
 }
 
 /**
@@ -322,7 +322,7 @@ uint8_t gas_read8(struct switchtec_dev *dev, uint8_t __gas *addr)
  */
 uint16_t gas_read16(struct switchtec_dev *dev, uint16_t __gas *addr)
 {
-	return dev->ops->gas_read16(dev, addr);
+	return __gas_read16(dev, addr);
 }
 
 /**
@@ -333,7 +333,7 @@ uint16_t gas_read16(struct switchtec_dev *dev, uint16_t __gas *addr)
  */
 uint32_t gas_read32(struct switchtec_dev *dev, uint32_t __gas *addr)
 {
-	return dev->ops->gas_read32(dev, addr);
+	return __gas_read32(dev, addr);
 }
 
 /**
@@ -344,7 +344,7 @@ uint32_t gas_read32(struct switchtec_dev *dev, uint32_t __gas *addr)
  */
 uint64_t gas_read64(struct switchtec_dev *dev, uint64_t __gas *addr)
 {
-	return dev->ops->gas_read64(dev, addr);
+	return __gas_read64(dev, addr);
 }
 
 /**
@@ -355,7 +355,7 @@ uint64_t gas_read64(struct switchtec_dev *dev, uint64_t __gas *addr)
  */
 void gas_write8(struct switchtec_dev *dev, uint8_t val, uint8_t __gas *addr)
 {
-	dev->ops->gas_write8(dev, val, addr);
+	__gas_write8(dev, val, addr);
 }
 
 /**
@@ -366,7 +366,7 @@ void gas_write8(struct switchtec_dev *dev, uint8_t val, uint8_t __gas *addr)
  */
 void gas_write16(struct switchtec_dev *dev, uint16_t val, uint16_t __gas *addr)
 {
-	dev->ops->gas_write16(dev, val, addr);
+	__gas_write16(dev, val, addr);
 }
 
 /**
@@ -377,7 +377,7 @@ void gas_write16(struct switchtec_dev *dev, uint16_t val, uint16_t __gas *addr)
  */
 void gas_write32(struct switchtec_dev *dev, uint32_t val, uint32_t __gas *addr)
 {
-	dev->ops->gas_write32(dev, val, addr);
+	__gas_write32(dev, val, addr);
 }
 
 /**
@@ -388,7 +388,7 @@ void gas_write32(struct switchtec_dev *dev, uint32_t val, uint32_t __gas *addr)
  */
 void gas_write64(struct switchtec_dev *dev, uint64_t val, uint64_t __gas *addr)
 {
-	dev->ops->gas_write64(dev, val, addr);
+	__gas_write64(dev, val, addr);
 }
 
 /**
@@ -401,7 +401,7 @@ void gas_write64(struct switchtec_dev *dev, uint64_t val, uint64_t __gas *addr)
 void memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
 		   const void *src, size_t n)
 {
-	dev->ops->memcpy_to_gas(dev, dest, src, n);
+	__memcpy_to_gas(dev, dest, src, n);
 }
 
 /**
@@ -414,7 +414,7 @@ void memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
 void memcpy_from_gas(struct switchtec_dev *dev, void *dest,
 		     const void __gas *src, size_t n)
 {
-	dev->ops->memcpy_from_gas(dev, dest, src, n);
+	__memcpy_from_gas(dev, dest, src, n);
 }
 
 /**
@@ -427,5 +427,5 @@ void memcpy_from_gas(struct switchtec_dev *dev, void *dest,
 ssize_t write_from_gas(struct switchtec_dev *dev, int fd,
 		       const void __gas *src, size_t n)
 {
-	return dev->ops->write_from_gas(dev, fd, src, n);
+	return __write_from_gas(dev, fd, src, n);
 }

--- a/lib/platform/platform.c
+++ b/lib/platform/platform.c
@@ -30,6 +30,7 @@
 #include "../switchtec_priv.h"
 #include "switchtec/switchtec.h"
 #include "switchtec/gas.h"
+#include "switchtec/gas_mrpc.h"
 #include "switchtec/errors.h"
 
 #include <errno.h>
@@ -311,6 +312,9 @@ int switchtec_event_wait(struct switchtec_dev *dev, int timeout_ms)
  */
 uint8_t gas_read8(struct switchtec_dev *dev, uint8_t __gas *addr)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		return gas_mrpc_read8(dev, addr);
+
 	return __gas_read8(dev, addr);
 }
 
@@ -322,6 +326,9 @@ uint8_t gas_read8(struct switchtec_dev *dev, uint8_t __gas *addr)
  */
 uint16_t gas_read16(struct switchtec_dev *dev, uint16_t __gas *addr)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		return gas_mrpc_read16(dev, addr);
+
 	return __gas_read16(dev, addr);
 }
 
@@ -333,6 +340,9 @@ uint16_t gas_read16(struct switchtec_dev *dev, uint16_t __gas *addr)
  */
 uint32_t gas_read32(struct switchtec_dev *dev, uint32_t __gas *addr)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		return gas_mrpc_read32(dev, addr);
+
 	return __gas_read32(dev, addr);
 }
 
@@ -344,6 +354,9 @@ uint32_t gas_read32(struct switchtec_dev *dev, uint32_t __gas *addr)
  */
 uint64_t gas_read64(struct switchtec_dev *dev, uint64_t __gas *addr)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		return gas_mrpc_read64(dev, addr);
+
 	return __gas_read64(dev, addr);
 }
 
@@ -355,6 +368,9 @@ uint64_t gas_read64(struct switchtec_dev *dev, uint64_t __gas *addr)
  */
 void gas_write8(struct switchtec_dev *dev, uint8_t val, uint8_t __gas *addr)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		gas_mrpc_write8(dev, val, addr);
+
 	__gas_write8(dev, val, addr);
 }
 
@@ -366,6 +382,9 @@ void gas_write8(struct switchtec_dev *dev, uint8_t val, uint8_t __gas *addr)
  */
 void gas_write16(struct switchtec_dev *dev, uint16_t val, uint16_t __gas *addr)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		gas_mrpc_write16(dev, val, addr);
+
 	__gas_write16(dev, val, addr);
 }
 
@@ -377,6 +396,9 @@ void gas_write16(struct switchtec_dev *dev, uint16_t val, uint16_t __gas *addr)
  */
 void gas_write32(struct switchtec_dev *dev, uint32_t val, uint32_t __gas *addr)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		gas_mrpc_write32(dev, val, addr);
+
 	__gas_write32(dev, val, addr);
 }
 
@@ -388,6 +410,9 @@ void gas_write32(struct switchtec_dev *dev, uint32_t val, uint32_t __gas *addr)
  */
 void gas_write64(struct switchtec_dev *dev, uint64_t val, uint64_t __gas *addr)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		gas_mrpc_write64(dev, val, addr);
+
 	__gas_write64(dev, val, addr);
 }
 
@@ -401,6 +426,9 @@ void gas_write64(struct switchtec_dev *dev, uint64_t val, uint64_t __gas *addr)
 void memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
 		   const void *src, size_t n)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		gas_mrpc_memcpy_to_gas(dev, dest, src, n);
+
 	__memcpy_to_gas(dev, dest, src, n);
 }
 
@@ -414,6 +442,9 @@ void memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
 void memcpy_from_gas(struct switchtec_dev *dev, void *dest,
 		     const void __gas *src, size_t n)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		gas_mrpc_memcpy_from_gas(dev, dest, src, n);
+
 	__memcpy_from_gas(dev, dest, src, n);
 }
 
@@ -427,5 +458,8 @@ void memcpy_from_gas(struct switchtec_dev *dev, void *dest,
 ssize_t write_from_gas(struct switchtec_dev *dev, int fd,
 		       const void __gas *src, size_t n)
 {
+	if (dev->pax_id != dev->local_pax_id)
+		gas_mrpc_write_from_gas(dev, fd, src, n);
+
 	return __write_from_gas(dev, fd, src, n);
 }

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -147,6 +147,25 @@ static int set_gen_variant(struct switchtec_dev * dev)
 	return 0;
 }
 
+static int set_local_pax_id(struct switchtec_dev *dev)
+{
+	unsigned char local_pax_id;
+	int ret;
+
+	dev->local_pax_id = -1;
+
+	if (!switchtec_is_pax(dev))
+		return 0;
+
+	ret = switchtec_cmd(dev, MRPC_GET_PAX_ID, NULL, 0,
+			    &local_pax_id, sizeof(local_pax_id));
+	if (ret)
+		return -1;
+
+	dev->local_pax_id = local_pax_id;
+	return 0;
+}
+
 /**
  * @brief Open a Switchtec device by string
  * @param[in] device A string representing the device to open
@@ -226,6 +245,9 @@ found:
 		errno = ENODEV;
 
 	if (set_gen_variant(ret))
+		return NULL;
+
+	if (set_local_pax_id(ret))
 		return NULL;
 
 	return ret;

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -317,7 +317,11 @@ int switchtec_set_pax_id(struct switchtec_dev *dev, int pax_id)
 	    (pax_id != SWITCHTEC_PAX_ID_LOCAL))
 		return -1;
 
-	dev->pax_id = pax_id;
+	if (pax_id == SWITCHTEC_PAX_ID_LOCAL)
+		dev->pax_id = dev->local_pax_id;
+	else
+		dev->pax_id = pax_id;
+
 	return 0;
 }
 

--- a/lib/switchtec_priv.h
+++ b/lib/switchtec_priv.h
@@ -94,6 +94,7 @@ struct switchtec_dev {
 	enum switchtec_gen gen;
 	enum switchtec_variant var;
 	int pax_id;
+	int local_pax_id;
 	int partition, partition_count;
 	char name[PATH_MAX];
 

--- a/lib/switchtec_priv.h
+++ b/lib/switchtec_priv.h
@@ -115,4 +115,70 @@ static inline void version_to_string(uint32_t version, char *buf, size_t buflen)
 
 const char *platform_strerror();
 
+static inline uint8_t __gas_read8(struct switchtec_dev *dev,
+				  uint8_t __gas *addr)
+{
+	return dev->ops->gas_read8(dev, addr);
+}
+
+static inline uint16_t __gas_read16(struct switchtec_dev *dev,
+				    uint16_t __gas *addr)
+{
+	return dev->ops->gas_read16(dev, addr);
+}
+
+static inline uint32_t __gas_read32(struct switchtec_dev *dev,
+				    uint32_t __gas *addr)
+{
+	return dev->ops->gas_read32(dev, addr);
+}
+
+static inline uint64_t __gas_read64(struct switchtec_dev *dev,
+				    uint64_t __gas *addr)
+{
+	return dev->ops->gas_read64(dev, addr);
+}
+
+static inline void __gas_write8(struct switchtec_dev *dev, uint8_t val,
+				uint8_t __gas *addr)
+{
+	dev->ops->gas_write8(dev, val, addr);
+}
+
+static inline void __gas_write16(struct switchtec_dev *dev, uint16_t val,
+				 uint16_t __gas *addr)
+{
+	dev->ops->gas_write16(dev, val, addr);
+}
+
+static inline void __gas_write32(struct switchtec_dev *dev, uint32_t val,
+				 uint32_t __gas *addr)
+{
+	dev->ops->gas_write32(dev, val, addr);
+}
+
+static inline void __gas_write64(struct switchtec_dev *dev, uint64_t val,
+				 uint64_t __gas *addr)
+{
+	dev->ops->gas_write64(dev, val, addr);
+}
+
+static inline void __memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
+		   const void *src, size_t n)
+{
+	dev->ops->memcpy_to_gas(dev, dest, src, n);
+}
+
+static inline void __memcpy_from_gas(struct switchtec_dev *dev, void *dest,
+		     const void __gas *src, size_t n)
+{
+	dev->ops->memcpy_from_gas(dev, dest, src, n);
+}
+
+static inline ssize_t __write_from_gas(struct switchtec_dev *dev, int fd,
+		       const void __gas *src, size_t n)
+{
+	return dev->ops->write_from_gas(dev, fd, src, n);
+}
+
 #endif


### PR DESCRIPTION
- Fix a typo 'create_gas_write'
- Introduce local_pax_id to make it possible to test if MRPC is targeting local the PAX switch