### PR TITLE
fw_footer cleanup

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1449,7 +1449,6 @@ static int fw_toggle(int argc, char **argv)
 static int fw_read(int argc, char **argv)
 {
 	const char *desc = "Flash the firmware with a new image";
-	struct switchtec_fw_footer ftr;
 	struct switchtec_fw_image_info active, inactive, *inf;
 	int ret = 0;
 	char version[16];
@@ -1490,20 +1489,12 @@ static int fw_read(int argc, char **argv)
 
 	inf = cfg.inactive ? &inactive : &active;
 
-	ret = switchtec_fw_read_footer(cfg.dev, inf->part_addr,
-				       inf->part_len, &ftr, version,
-				       sizeof(version));
-	if (ret < 0) {
-		switchtec_perror("fw_read_footer");
-		goto close_and_exit;
-	}
-
 	fprintf(stderr, "Version:  %s\n", version);
 	fprintf(stderr, "Type:     %s\n", cfg.data ? "DAT" : "IMG");
-	fprintf(stderr, "Img Len:  0x%x\n", (int) ftr.image_len);
-	fprintf(stderr, "CRC:      0x%x\n", (int) ftr.image_crc);
+	fprintf(stderr, "Img Len:  0x%zx\n", inf->image_len);
+	fprintf(stderr, "CRC:      0x%zx\n", inf->image_crc);
 
-	ret = switchtec_fw_img_write_hdr(cfg.out_fd, &ftr, inf->type);
+	ret = switchtec_fw_img_write_hdr(cfg.out_fd, inf);
 	if (ret < 0) {
 		switchtec_perror(cfg.out_filename);
 		goto close_and_exit;
@@ -1511,7 +1502,7 @@ static int fw_read(int argc, char **argv)
 
 	progress_start();
 	ret = switchtec_fw_read_fd(cfg.dev, cfg.out_fd, inf->part_addr,
-				   ftr.image_len, progress_update);
+				   inf->image_len, progress_update);
 	progress_finish();
 
 	if (ret < 0)

--- a/cli/main.c
+++ b/cli/main.c
@@ -1175,7 +1175,7 @@ static enum switchtec_fw_image_type check_and_print_fw_image(
 	printf("Type:     %s\n", switchtec_fw_image_type(&info));
 	printf("Version:  %s\n", info.version);
 	printf("Img Len:  0x%" FMT_SIZE_T_x "\n", info.image_len);
-	printf("CRC:      0x%08lx\n", info.crc);
+	printf("CRC:      0x%08lx\n", info.image_crc);
 
 	return info.type;
 }
@@ -1264,10 +1264,10 @@ static int print_fw_part_info(struct switchtec_dev *dev)
 	       map_ver, (long)map.image_crc,
 	       bootloader_ro ? "(RO)" : "");
 	printf("  IMG  \tVersion: %-8s\tCRC: %08lx%s\n",
-	       act_img.version, act_img.crc,
+	       act_img.version, act_img.image_crc,
 	       fw_running_string(&act_img));
 	printf("  CFG  \tVersion: %-8s\tCRC: %08lx%s\n",
-	       act_cfg.version, act_cfg.crc,
+	       act_cfg.version, act_cfg.image_crc,
 	       fw_running_string(&act_cfg));
 
 	for (i = 0; i < nr_mult; i++) {
@@ -1277,10 +1277,10 @@ static int print_fw_part_info(struct switchtec_dev *dev)
 
 	printf("Inactive Partition:\n");
 	printf("  IMG  \tVersion: %-8s\tCRC: %08lx%s\n",
-	       inact_img.version, inact_img.crc,
+	       inact_img.version, inact_img.image_crc,
 	       fw_running_string(&inact_img));
 	printf("  CFG  \tVersion: %-8s\tCRC: %08lx%s\n",
-	       inact_cfg.version, inact_cfg.crc,
+	       inact_cfg.version, inact_cfg.image_crc,
 	       fw_running_string(&inact_cfg));
 
 	return 0;
@@ -1490,8 +1490,8 @@ static int fw_read(int argc, char **argv)
 
 	inf = cfg.inactive ? &inactive : &active;
 
-	ret = switchtec_fw_read_footer(cfg.dev, inf->image_addr,
-				       inf->image_len, &ftr, version,
+	ret = switchtec_fw_read_footer(cfg.dev, inf->part_addr,
+				       inf->part_len, &ftr, version,
 				       sizeof(version));
 	if (ret < 0) {
 		switchtec_perror("fw_read_footer");
@@ -1510,7 +1510,7 @@ static int fw_read(int argc, char **argv)
 	}
 
 	progress_start();
-	ret = switchtec_fw_read_fd(cfg.dev, cfg.out_fd, inf->image_addr,
+	ret = switchtec_fw_read_fd(cfg.dev, cfg.out_fd, inf->part_addr,
 				   ftr.image_len, progress_update);
 	progress_finish();
 

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -545,22 +545,6 @@ static inline int switchtec_fw_running(struct switchtec_fw_image_info *inf)
 	return inf->active & SWITCHTEC_FW_PART_RUNNING;
 }
 
-
-/**
- * @brief Raw firmware image header/footer
- *
- * Avoid using this directly
- */
-struct switchtec_fw_footer {
-	char magic[4];
-	uint32_t image_len;
-	uint32_t load_addr;
-	uint32_t version;
-	uint32_t rsvd;
-	uint32_t header_crc;
-	uint32_t image_crc;
-};
-
 int switchtec_fw_dlstatus(struct switchtec_dev *dev,
 			  enum switchtec_fw_dlstatus *status,
 			  enum mrpc_bg_status *bgstatus);
@@ -579,11 +563,6 @@ int switchtec_fw_read_fd(struct switchtec_dev *dev, int fd,
 			 void (*progress_callback)(int cur, int tot));
 int switchtec_fw_read(struct switchtec_dev *dev, unsigned long addr,
 		      size_t len, void *buf);
-int switchtec_fw_read_footer(struct switchtec_dev *dev,
-			     unsigned long partition_start,
-			     size_t partition_len,
-			     struct switchtec_fw_footer *ftr,
-			     char *version, size_t version_len);
 void switchtec_fw_perror(const char *s, int ret);
 int switchtec_fw_file_info(int fd, struct switchtec_fw_image_info *info);
 const char *switchtec_fw_image_type(const struct switchtec_fw_image_info *info);

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -196,6 +196,8 @@ struct switchtec_fw_image_info {
 	size_t image_addr;			//!< Address of the image
 	size_t image_len;			//!< Length of the image
 	unsigned long image_crc;		//!< CRC checksum of the image
+	unsigned long header_crc;		//!< CRC checksum of the header
+	unsigned long version_packed;		//!< Raw binary version number
 
 	/**
 	 * @brief Flags indicating if an image is active and/or running
@@ -598,8 +600,7 @@ int switchtec_fw_cfg_info(struct switchtec_dev *dev,
 			  struct switchtec_fw_image_info *inact_cfg,
 			  struct switchtec_fw_image_info *mult_cfg,
 			  int *nr_mult);
-int switchtec_fw_img_write_hdr(int fd, struct switchtec_fw_footer *ftr,
-			       enum switchtec_fw_image_type type);
+int switchtec_fw_img_write_hdr(int fd, struct switchtec_fw_image_info *inf);
 int switchtec_fw_is_boot_ro(struct switchtec_dev *dev);
 int switchtec_fw_set_boot_ro(struct switchtec_dev *dev,
 			     enum switchtec_fw_ro ro);

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -191,9 +191,11 @@ enum switchtec_fw_image_type {
 struct switchtec_fw_image_info {
 	enum switchtec_fw_image_type type;	//!< Image type
 	char version[32];			//!< Firmware/Config version
+	size_t part_addr;			//!< Address of the partition
+	size_t part_len;			//!< Length of the partition
 	size_t image_addr;			//!< Address of the image
 	size_t image_len;			//!< Length of the image
-	unsigned long crc;			//!< CRC checksum of the image
+	unsigned long image_crc;		//!< CRC checksum of the image
 
 	/**
 	 * @brief Flags indicating if an image is active and/or running

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -584,9 +584,6 @@ int switchtec_fw_read_footer(struct switchtec_dev *dev,
 			     size_t partition_len,
 			     struct switchtec_fw_footer *ftr,
 			     char *version, size_t version_len);
-int switchtec_fw_read_active_map_footer(struct switchtec_dev *dev,
-					struct switchtec_fw_footer *ftr,
-					char *version, size_t version_len);
 void switchtec_fw_perror(const char *s, int ret);
 int switchtec_fw_file_info(int fd, struct switchtec_fw_image_info *info);
 const char *switchtec_fw_image_type(const struct switchtec_fw_image_info *info);

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -827,43 +827,6 @@ int switchtec_fw_read_footer(struct switchtec_dev *dev,
 }
 
 /**
- * @brief Read Switchtec device's active map partition footer
- * @param[in]  dev		Switchtec device handle
- * @param[out] ftr		The footer structure to populate
- * @param[out] version		Optional pointer to a string which will
- *	be populated with a human readable string of the version
- * @param[in]  version_len	Maximum length of the version string
- * @return 0 on success, error code on failure
- */
-int switchtec_fw_read_active_map_footer(struct switchtec_dev *dev,
-					struct switchtec_fw_footer *ftr,
-					char *version, size_t version_len)
-{
-	int ret;
-	uint32_t map0_update_index;
-	uint32_t map1_update_index;
-	unsigned long active_map_part_start = SWITCHTEC_FLASH_MAP0_PART_START;
-
-	ret = switchtec_fw_read(dev, SWITCHTEC_FLASH_MAP0_PART_START,
-				sizeof(uint32_t), &map0_update_index);
-	if (ret < 0)
-		return ret;
-
-	ret = switchtec_fw_read(dev, SWITCHTEC_FLASH_MAP1_PART_START,
-				sizeof(uint32_t), &map1_update_index);
-	if (ret < 0)
-		return ret;
-
-	if (map0_update_index < map1_update_index)
-		active_map_part_start = SWITCHTEC_FLASH_MAP1_PART_START;
-
-
-	return switchtec_fw_read_footer(dev, active_map_part_start,
-					SWITCHTEC_FLASH_PART_LEN, ftr, version,
-					version_len);
-}
-
-/**
  * @brief Write the header for a Switchtec firmware image file
  * @param[in]  fd	File descriptor for image file to write
  * @param[in]  ftr	Footer information to include in the header

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -495,6 +495,8 @@ int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
 			inf->image_crc = ftr.image_crc;
 			inf->image_addr = ftr.load_addr;
 			inf->image_len = ftr.image_len;
+			inf->header_crc = ftr.header_crc;
+			inf->version_packed = ftr.version;
 		}
 	}
 
@@ -821,18 +823,17 @@ int switchtec_fw_read_active_map_footer(struct switchtec_dev *dev,
  * @param[in]  type	File type to record in the header
  * @return 0 on success, error code on failure
  */
-int switchtec_fw_img_write_hdr(int fd, struct switchtec_fw_footer *ftr,
-			       enum switchtec_fw_image_type type)
+int switchtec_fw_img_write_hdr(int fd, struct switchtec_fw_image_info *inf)
 {
 	struct fw_image_header hdr = {};
 
-	memcpy(hdr.magic, ftr->magic, sizeof(hdr.magic));
-	hdr.image_len = ftr->image_len;
-	hdr.type = type;
-	hdr.load_addr = ftr->load_addr;
-	hdr.version = ftr->version;
-	hdr.header_crc = ftr->header_crc;
-	hdr.image_crc = ftr->image_crc;
+	memcpy(hdr.magic, "PMC", sizeof(hdr.magic));
+	hdr.image_len = inf->image_len;
+	hdr.type = inf->type;
+	hdr.load_addr = inf->image_addr;
+	hdr.version = inf->version_packed;
+	hdr.header_crc = inf->header_crc;
+	hdr.image_crc = inf->image_crc;
 
 	if (hdr.type == SWITCHTEC_FW_TYPE_MAP1)
 		hdr.type = SWITCHTEC_FW_TYPE_MAP0;

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -451,6 +451,55 @@ const char *switchtec_fw_image_type(const struct switchtec_fw_image_info *info)
 	}
 }
 
+struct switchtec_fw_footer_gen3 {
+	char magic[4];
+	uint32_t image_len;
+	uint32_t load_addr;
+	uint32_t version;
+	uint32_t rsvd;
+	uint32_t header_crc;
+	uint32_t image_crc;
+};
+
+/**
+ * @brief Read a Switchtec device's firmware partition footer
+ * @param[in]  dev		Switchtec device handle
+ * @param[in]  partition_start	Partition start address
+ * @param[in]  partition_len	Partition length
+ * @param[out] ftr		The footer structure to populate
+ * @param[out] version		Optional pointer to a string which will
+ *	be populated with a human readable string of the version
+ * @param[in]  version_len	Maximum length of the version string
+ * @return 0 on success, error code on failure
+ */
+static int switchtec_fw_read_gen3_footer(struct switchtec_dev *dev,
+					 unsigned long partition_start,
+					 size_t partition_len,
+					 struct switchtec_fw_footer_gen3 *ftr,
+					 char *version, size_t version_len)
+{
+	int ret;
+	unsigned long addr = partition_start + partition_len -
+		sizeof(struct switchtec_fw_footer_gen3);
+
+	if (!ftr)
+		return -EINVAL;
+
+	ret = switchtec_fw_read(dev, addr, sizeof(*ftr), ftr);
+	if (ret < 0)
+		return ret;
+
+	if (strcmp(ftr->magic, "PMC") != 0) {
+		errno = ENOEXEC;
+		return -errno;
+	}
+
+	if (version)
+		version_to_string(ftr->version, version, version_len);
+
+	return 0;
+}
+
 static int switchtec_fw_map_get_active(struct switchtec_dev *dev,
 				       struct switchtec_fw_image_info *info)
 {
@@ -494,7 +543,7 @@ int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
 {
 	int ret;
 	int i;
-	struct switchtec_fw_footer ftr;
+	struct switchtec_fw_footer_gen3 ftr;
 
 	if (info == NULL || nr_info == 0)
 		return -EINVAL;
@@ -531,10 +580,10 @@ int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
 			continue;
 		}
 
-		ret = switchtec_fw_read_footer(dev, inf->part_addr,
-					       inf->part_len, &ftr,
-					       inf->version,
-					       sizeof(inf->version));
+		ret = switchtec_fw_read_gen3_footer(dev, inf->part_addr,
+						    inf->part_len, &ftr,
+						    inf->version,
+						    sizeof(inf->version));
 		if (ret < 0) {
 			inf->version[0] = 0;
 			inf->image_crc = 0xFFFFFFFF;
@@ -784,46 +833,6 @@ int switchtec_fw_read_fd(struct switchtec_dev *dev, int fd,
 	}
 
 	return read;
-}
-
-/**
- * @brief Read a Switchtec device's firmware partition footer
- * @param[in]  dev		Switchtec device handle
- * @param[in]  partition_start	Partition start address
- * @param[in]  partition_len	Partition length
- * @param[out] ftr		The footer structure to populate
- * @param[out] version		Optional pointer to a string which will
- *	be populated with a human readable string of the version
- * @param[in]  version_len	Maximum length of the version string
- * @return 0 on success, error code on failure
- */
-int switchtec_fw_read_footer(struct switchtec_dev *dev,
-			     unsigned long partition_start,
-			     size_t partition_len,
-			     struct switchtec_fw_footer *ftr,
-			     char *version, size_t version_len)
-{
-	int ret;
-	unsigned long addr = partition_start + partition_len -
-		sizeof(struct switchtec_fw_footer);
-
-	if (!ftr)
-		return -EINVAL;
-
-	ret = switchtec_fw_read(dev, addr, sizeof(struct switchtec_fw_footer),
-				ftr);
-	if (ret < 0)
-		return ret;
-
-	if (strcmp(ftr->magic, "PMC") != 0) {
-		errno = ENOEXEC;
-		return -errno;
-	}
-
-	if (version)
-		version_to_string(ftr->version, version, version_len);
-
-	return 0;
 }
 
 /**

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -832,6 +832,13 @@ int switchtec_fw_img_write_hdr(int fd, struct switchtec_fw_footer *ftr,
 	hdr.header_crc = ftr->header_crc;
 	hdr.image_crc = ftr->image_crc;
 
+	if (hdr.type == SWITCHTEC_FW_TYPE_MAP1)
+		hdr.type = SWITCHTEC_FW_TYPE_MAP0;
+	else if (hdr.type == SWITCHTEC_FW_TYPE_IMG1)
+		hdr.type = SWITCHTEC_FW_TYPE_IMG0;
+	else if (hdr.type == SWITCHTEC_FW_TYPE_DAT1)
+		hdr.type = SWITCHTEC_FW_TYPE_DAT0;
+
 	return write(fd, &hdr, sizeof(hdr));
 }
 

--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -198,8 +198,8 @@ static void set_fw_info_part(struct switchtec_dev *dev,
 			     struct switchtec_fw_image_info *info,
 			     struct partition_info __gas *pi)
 {
-	info->image_addr = __gas_read32(dev, &pi->address);
-	info->image_len = __gas_read32(dev, &pi->length);
+	info->part_addr = __gas_read32(dev, &pi->address);
+	info->part_len = __gas_read32(dev, &pi->length);
 }
 
 int gasop_flash_part(struct switchtec_dev *dev,
@@ -258,7 +258,7 @@ int gasop_flash_part(struct switchtec_dev *dev,
 		return -EINVAL;
 	}
 
-	if (info->image_addr == active_addr)
+	if (info->part_addr == active_addr)
 		info->active |= SWITCHTEC_FW_PART_ACTIVE;
 
 	return 0;

--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -796,8 +796,8 @@ static int linux_flash_part(struct switchtec_dev *dev,
 	if (ret)
 		return ret;
 
-	info->image_addr = ioctl_info.address;
-	info->image_len = ioctl_info.length;
+	info->part_addr = ioctl_info.address;
+	info->part_len = ioctl_info.length;
 	info->active = ioctl_info.active;
 	return 0;
 }


### PR DESCRIPTION
Here's a few patches in the direction PR #106 is going.

The goal of this set is to remove fw_footer from the interface used in the CLI seeing it's information
is very much hardware dependent and goes away in gen4.