### PR TITLE
Fix a bug in switchtec_open

### DIFF
--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -239,10 +239,12 @@ struct switchtec_dev *switchtec_open(const char *device)
 	return NULL;
 
 found:
-	if (ret)
-		snprintf(ret->name, sizeof(ret->name), "%s", device);
-	else
+	if (!ret) {
 		errno = ENODEV;
+		return NULL;
+	}
+
+	snprintf(ret->name, sizeof(ret->name), "%s", device);
 
 	if (set_gen_variant(ret))
 		return NULL;


### PR DESCRIPTION
When the device node is neither exist nor accessible due to insufficient
permission, the open function will cause segmentation fault. Fix it
in this patch.