### PR TITLE
Fixed fw-info fail when some partitions are missing

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1220,7 +1220,7 @@ static const char *fw_active_string(struct switchtec_fw_image_info *inf)
 static void print_fw_part_line(const char *tag,
 			       struct switchtec_fw_image_info *inf)
 {
-	if (!inf)
+	if (!inf || !inf->valid)
 		return;
 
 	printf("  %-4s\tVersion: %-8s\tCRC: %08lx%s%s\n",

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -205,6 +205,7 @@ struct switchtec_fw_image_info {
 	size_t image_len;			//!< Length of the image
 	unsigned long image_crc;		//!< CRC checksum of the image
 
+	bool valid;
 	bool active;
 	bool running;
 	bool read_only;

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -835,6 +835,8 @@ static int switchtec_fw_part_info_gen3(struct switchtec_dev *dev,
 	if (ret)
 		return ret;
 
+	inf->valid = 1;
+
 	if (inf->part_id == SWITCHTEC_FW_PART_ID_G3_NVLOG)
 		return 1;
 

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -960,6 +960,10 @@ static int switchtec_fw_part_info_gen4(struct switchtec_dev *dev,
 		return -1;
 	}
 
+	inf->valid = part_info->valid;
+	if(!inf->valid)
+		return 0;
+
 	inf->part_addr = part_info->part_start;
 	inf->part_len = part_info->part_size_dw * 4;
 	inf->active = part_info->active;
@@ -1206,6 +1210,9 @@ switchtec_fw_part_summary(struct switchtec_dev *dev)
 
 	for (i = 0; i < nr_info; i++) {
 		type = switchtec_fw_type_ptr(summary, &summary->all[i]);
+		if(!summary->all[i].valid)
+			continue;
+
 		if (summary->all[i].active)
 			type->active = &summary->all[i];
 		else


### PR DESCRIPTION
Check valid flag in partition to make sure only the valid partitions are processed.