### PR TITLE
Check RSA_get0_key() presense in libssl-dev

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -3,8 +3,15 @@
 /* Define to 1 if you have the <curses.h> header file. */
 #undef HAVE_CURSES_H
 
+/* Define to 1 if you have the declaration of `RSA_get0_key', and to 0 if you
+   don't. */
+#undef HAVE_DECL_RSA_GET0_KEY
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
+
+/* Define to 1 if you have the `crypto' library (-lcrypto). */
+#undef HAVE_LIBCRYPTO
 
 /* Define to 1 if you have the `curses' library (-lcurses). */
 #undef HAVE_LIBCURSES

--- a/configure
+++ b/configure
@@ -1676,6 +1676,52 @@ $as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_header_compile
+
+# ac_fn_c_check_decl LINENO SYMBOL VAR INCLUDES
+# ---------------------------------------------
+# Tests whether SYMBOL is declared in INCLUDES, setting cache variable VAR
+# accordingly.
+ac_fn_c_check_decl ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  as_decl_name=`echo $2|sed 's/ *(.*//'`
+  as_decl_use=`echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g'`
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
+$as_echo_n "checking whether $as_decl_name is declared... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+#ifndef $as_decl_name
+#ifdef __cplusplus
+  (void) $as_decl_use;
+#else
+  (void) $as_decl_name;
+#endif
+#endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$3=yes"
+else
+  eval "$3=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_decl
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -3528,6 +3574,21 @@ _ACEOF
   LIBS="-lcrypto $LIBS"
 
 fi
+
+fi
+
+if test "x$with_ssl" != xno; then :
+  ac_fn_c_check_decl "$LINENO" "RSA_get0_key" "ac_cv_have_decl_RSA_get0_key" "#include <openssl/pem.h>
+"
+if test "x$ac_cv_have_decl_RSA_get0_key" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_RSA_GET0_KEY $ac_have_decl
+_ACEOF
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,9 @@ AC_CHECK_HEADERS([curses.h ncurses/curses.h])
 AS_IF([test "x$with_ssl" != xno],
        [AC_CHECK_LIB([crypto], [RSA_free], [], [], [])])
 
+AS_IF([test "x$with_ssl" != xno],
+       [AC_CHECK_DECLS([RSA_get0_key], [], [], [#include <openssl/pem.h>])])
+
 AC_CONFIG_FILES([Makefile])
 
 AC_CONFIG_HEADER([config.h])

--- a/lib/recovery.c
+++ b/lib/recovery.c
@@ -45,6 +45,7 @@
 #include <openssl/pem.h>
 
 #include "lib/crc32.h"
+#include "config.h"
 
 #define SWITCHTEC_ACTV_IMG_ID_KMAN		1
 #define SWITCHTEC_ACTV_IMG_ID_BL2		2
@@ -64,7 +65,7 @@
 #define SWITCHTEC_I2C_ADDR_BITSHIFT		22
 #define SWITCHTEC_CMD_MAP_BITSHIFT		29
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if !HAVE_DECL_RSA_GET0_KEY
 /**
 *  openssl1.0 or older versions don't have this function, so copy
 *  the code from openssl1.1 here


### PR DESCRIPTION
Libssl-dev 1.0 or older versions don't have this function. Add
presense check of this function in ./configure and define it if
it is not present in the installed version of libssl-dev.

Note: We still need to handle the case when libssl-dev is not available
in upcoming commit. We should allow user who doesn't care about
'recovery' features to compile the code.