### PR TITLE
Changed behavior of -y option in recovery commands 

### DIFF
--- a/cli/recovery.c
+++ b/cli/recovery.c
@@ -495,7 +495,7 @@ static int fw_transfer(int argc, char **argv)
 		struct switchtec_dev *dev;
 		FILE *fimg;
 		const char *img_filename;
-		int confirm;
+		int assume_yes;
 		int force;
 	} cfg = {};
 	const struct argconfig_options opts[] = {
@@ -503,7 +503,7 @@ static int fw_transfer(int argc, char **argv)
 		{"img_file", .cfg_type=CFG_FILE_R, .value_addr=&cfg.fimg,
 			.argument_type=required_positional,
 			.help="firmware image file to transfer"},
-		{"yes", 'y', "", CFG_NONE, &cfg.confirm, no_argument,
+		{"yes", 'y', "", CFG_NONE, &cfg.assume_yes, no_argument,
 			"assume yes when prompted"},
 		{"force", 'f', "", CFG_NONE, &cfg.force, no_argument,
 			"force interrupting an existing fw-update command "
@@ -544,7 +544,7 @@ static int fw_transfer(int argc, char **argv)
 
 	print_fw_image_info(cfg.img_filename, &finfo);
 
-	ret = ask_if_sure(cfg.confirm);
+	ret = ask_if_sure(cfg.assume_yes);
 	if (ret) {
 		fclose(cfg.fimg);
 		return ret;
@@ -576,12 +576,12 @@ static int fw_execute(int argc, char **argv)
 	const char *desc = "Execute the transferred firmware image (BL1 only)";
 	static struct {
 		struct switchtec_dev *dev;
-		int confirm;
+		int assume_yes;
 		enum switchtec_bl2_recovery_mode bl2_rec_mode;
 	} cfg = {};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
-		{"yes", 'y', "", CFG_NONE, &cfg.confirm, no_argument,
+		{"yes", 'y', "", CFG_NONE, &cfg.assume_yes, no_argument,
 			"assume yes when prompted"},
 		{"bl2_recovery_mode", 'm', "MODE", CFG_CHOICES, &cfg.bl2_rec_mode,
 			required_argument, "BL2 recovery mode",
@@ -612,7 +612,7 @@ static int fw_execute(int argc, char **argv)
 		return -2;
 	}
 
-	ret = ask_if_sure(cfg.confirm);
+	ret = ask_if_sure(cfg.assume_yes);
 	if (ret) {
 		return ret;
 	}
@@ -1001,7 +1001,7 @@ static int dport_lock_update(int argc, char **argv)
 		unsigned int serial;
 		FILE *sig_fimg;
 		char *sig_file;
-		unsigned int confirm;
+		unsigned int assume_yes;
 	} cfg = {};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
@@ -1021,7 +1021,7 @@ static int dport_lock_update(int argc, char **argv)
 			.value_addr=&cfg.sig_fimg,
 			.argument_type=required_argument,
 			.help="signature file"},
-		{"yes", 'y', "", CFG_NONE, &cfg.confirm, no_argument,
+		{"yes", 'y', "", CFG_NONE, &cfg.assume_yes, no_argument,
 			"assume yes when prompted"},
 		{NULL}
 	};
@@ -1040,7 +1040,7 @@ static int dport_lock_update(int argc, char **argv)
 		return -2;
 	}
 
-	ret = ask_if_sure(cfg.confirm);
+	ret = ask_if_sure(cfg.assume_yes);
 	if (ret) {
 		return ret;
 	}

--- a/cli/recovery.c
+++ b/cli/recovery.c
@@ -504,7 +504,7 @@ static int fw_transfer(int argc, char **argv)
 			.argument_type=required_positional,
 			.help="firmware image file to transfer"},
 		{"yes", 'y', "", CFG_NONE, &cfg.confirm, no_argument,
-			"double confirm before execution"},
+			"assume yes when prompted"},
 		{"force", 'f', "", CFG_NONE, &cfg.force, no_argument,
 			"force interrupting an existing fw-update command "
 			"in case firmware is stuck in the busy state"},
@@ -544,7 +544,7 @@ static int fw_transfer(int argc, char **argv)
 
 	print_fw_image_info(cfg.img_filename, &finfo);
 
-	ret = ask_if_sure(!cfg.confirm);
+	ret = ask_if_sure(cfg.confirm);
 	if (ret) {
 		fclose(cfg.fimg);
 		return ret;
@@ -582,7 +582,7 @@ static int fw_execute(int argc, char **argv)
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
 		{"yes", 'y', "", CFG_NONE, &cfg.confirm, no_argument,
-			"double confirm before execution"},
+			"assume yes when prompted"},
 		{"bl2_recovery_mode", 'm', "MODE", CFG_CHOICES, &cfg.bl2_rec_mode,
 			required_argument, "BL2 recovery mode",
 			.choices = recovery_mode_choices},
@@ -612,7 +612,7 @@ static int fw_execute(int argc, char **argv)
 		return -2;
 	}
 
-	ret = ask_if_sure(!cfg.confirm);
+	ret = ask_if_sure(cfg.confirm);
 	if (ret) {
 		return ret;
 	}
@@ -1022,7 +1022,7 @@ static int dport_lock_update(int argc, char **argv)
 			.argument_type=required_argument,
 			.help="signature file"},
 		{"yes", 'y', "", CFG_NONE, &cfg.confirm, no_argument,
-			"double confirm before update"},
+			"assume yes when prompted"},
 		{NULL}
 	};
 
@@ -1040,7 +1040,7 @@ static int dport_lock_update(int argc, char **argv)
 		return -2;
 	}
 
-	ret = ask_if_sure(!cfg.confirm);
+	ret = ask_if_sure(cfg.confirm);
 	if (ret) {
 		return ret;
 	}


### PR DESCRIPTION
Changed behavior of -y option in recovery commands so that it is consistent with other main menu commands.