### PR TITLE
Fix a bug of fw-read on gen4 switch

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1497,8 +1497,8 @@ static int fw_read(int argc, char **argv)
 	}
 
 	progress_start();
-	ret = switchtec_fw_read_fd(cfg.dev, cfg.out_fd, inf->part_addr,
-				   inf->image_len, progress_update);
+	ret = switchtec_fw_body_read_fd(cfg.dev, cfg.out_fd,
+					inf, progress_update);
 	progress_finish();
 
 	if (ret < 0)

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -196,6 +196,7 @@ struct switchtec_fw_image_info {
 	char version[32];			//!< Firmware/Config version
 	size_t part_addr;			//!< Address of the partition
 	size_t part_len;			//!< Length of the partition
+	size_t part_body_offset;		//!< Partition image body offset
 	size_t image_len;			//!< Length of the image
 	unsigned long image_crc;		//!< CRC checksum of the image
 
@@ -654,6 +655,9 @@ int switchtec_fw_write_file(struct switchtec_dev *dev, FILE *fimg,
 int switchtec_fw_read_fd(struct switchtec_dev *dev, int fd,
 			 unsigned long addr, size_t len,
 			 void (*progress_callback)(int cur, int tot));
+int switchtec_fw_body_read_fd(struct switchtec_dev *dev, int fd,
+			      struct switchtec_fw_image_info *info,
+			      void (*progress_callback)(int cur, int tot));
 int switchtec_fw_read(struct switchtec_dev *dev, unsigned long addr,
 		      size_t len, void *buf);
 void switchtec_fw_perror(const char *s, int ret);

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -699,6 +699,7 @@ static int switchtec_fw_info_metadata_gen3(struct switchtec_dev *dev,
 
 	version_to_string(metadata->version, inf->version,
 			  sizeof(inf->version));
+	inf->part_body_offset = 0;
 	inf->image_crc = metadata->image_crc;
 	inf->image_len = metadata->image_len;
 	inf->metadata = metadata;
@@ -780,6 +781,7 @@ static int switchtec_fw_info_metadata_gen4(struct switchtec_dev *dev,
 
 	version_to_string(metadata->version, inf->version,
 			  sizeof(inf->version));
+	inf->part_body_offset = metadata->header_len;
 	inf->image_crc = metadata->image_crc;
 	inf->image_len = metadata->image_len;
 	inf->metadata = metadata;
@@ -1223,6 +1225,24 @@ int switchtec_fw_read_fd(struct switchtec_dev *dev, int fd,
 	return read;
 }
 
+/**
+ * @brief Read a Switchtec device's flash image body into a file
+ * @param[in]  dev     Switchtec device handle
+ * @param[in]  fd      File descriptor for image file to write
+ * @param[in]  info    Partition information structure
+ * @param[in]  progress_callback This function is called periodically to
+ *     indicate the progress of the read. May be NULL.
+ * @return number of bytes written on success, error code on failure
+ */
+int switchtec_fw_body_read_fd(struct switchtec_dev *dev, int fd,
+			      struct switchtec_fw_image_info *info,
+			      void (*progress_callback)(int cur, int tot))
+{
+	return switchtec_fw_read_fd(dev, fd,
+				    info->part_addr + info->part_body_offset,
+				    info->image_len, progress_callback);
+}
+
 static int switchtec_fw_img_write_hdr_gen3(int fd,
 		struct switchtec_fw_image_info *info)
 {
@@ -1250,16 +1270,28 @@ static int switchtec_fw_img_write_hdr_gen3(int fd,
 static int switchtec_fw_img_write_hdr_gen4(int fd,
 		struct switchtec_fw_image_info *info)
 {
+	int ret;
 	struct switchtec_fw_metadata_gen4 *hdr = info->metadata;
 
-	return write(fd, hdr, sizeof(*hdr));
+	ret = write(fd, hdr, sizeof(*hdr));
+	if (ret < 0)
+		return ret;
+
+	return lseek(fd, info->part_body_offset, SEEK_SET);
 }
 
 /**
  * @brief Write the header for a Switchtec firmware image file
  * @param[in]  fd	File descriptor for image file to write
  * @param[in]  info	Partition information structure
- * @return 0 on success, error code on failure
+ * @return number of bytes written on success, error code on failure
+ *
+ * The offset of image body in the image file is greater than or equal to
+ * the image header length. This function also repositions the read/write
+ * file offset of fd to the offset of image body in the image file if
+ * needed. This will facilitate the switchtec_fw_read_fd() function which
+ * is usually called following this function to complete a firmware image
+ * read.
  */
 int switchtec_fw_img_write_hdr(int fd, struct switchtec_fw_image_info *info)
 {


### PR DESCRIPTION
The fw image layout on the fw partition changed in Gen4, the metadata is
placed at the very beginning of the partition, rather than at the foot
in Gen3. The Gen4 fw image file layout is also changed, the image body is
placed at offset 0x1000, rather than immediatly after the image header.

This fix makes sure for a fw-read on Gen4 switch that
1, The image body is read from correct offset from a fw partition.
2, The image body is written to the correct offset of a image file.