### PR TITLE
Fixed seg fault in fw-read if key manifest not exist

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1618,7 +1618,7 @@ static int fw_read(int argc, char **argv)
 
 	if (!inf || !inf->valid) {
 		ret = -1;
-		fprintf(stderr, "fw_part_summary: No valid image for this partition!\n");
+		fprintf(stderr, "No valid image for this partition!\n");
 		goto close_and_exit;
 	}
 

--- a/cli/main.c
+++ b/cli/main.c
@@ -1616,6 +1616,12 @@ static int fw_read(int argc, char **argv)
 	else
 		inf = cfg.inactive ? sum->img.inactive : sum->img.active;
 
+	if (!inf || !inf->valid) {
+		ret = -1;
+		fprintf(stderr, "fw_part_summary: No valid image for this partition!\n");
+		goto close_and_exit;
+	}
+
 	fprintf(stderr, "Version:  %s\n", inf->version);
 	fprintf(stderr, "Type:     %s\n",
 		cfg.data ? "DAT" : cfg.bl2? "BL2" : cfg.key? "KEY" : "IMG");


### PR DESCRIPTION
Fixed segmentation fault in fw-read when key manifest does not exist.