### PR TITLE
Secure boot kmsk missing param fix

### DIFF
--- a/cli/recovery.c
+++ b/cli/recovery.c
@@ -977,7 +977,22 @@ static int dport_unlock(int argc, char **argv)
 		{NULL}
 	};
 
+	cfg.serial = 0;
+	cfg.unlock_version = 0xffff;
+
 	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
+
+	if(cfg.serial == 0) {
+		fprintf(stderr,
+			"Serial number must be set in this command!\n");
+		return -1;
+	}
+
+	if(cfg.unlock_version == 0xffff) {
+		fprintf(stderr,
+			"Unlock version must be set in this command!\n");
+		return -1;
+	}
 
 	if (cfg.pubkey_file == NULL) {
 		fprintf(stderr,
@@ -1058,7 +1073,22 @@ static int dport_lock_update(int argc, char **argv)
 		{NULL}
 	};
 
+	cfg.serial = 0;
+	cfg.unlock_version = 0xffff;
+
 	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
+
+	if(cfg.serial == 0) {
+		fprintf(stderr,
+			"Serial number must be set in this command!\n");
+		return -1;
+	}
+
+	if(cfg.unlock_version == 0xffff) {
+		fprintf(stderr,
+			"Unlock version must be set in this command!\n");
+		return -1;
+	}
 
 	if (cfg.pubkey_file == NULL) {
 		fprintf(stderr,

--- a/cli/recovery.c
+++ b/cli/recovery.c
@@ -782,6 +782,13 @@ static int kmsk_add(int argc, char **argv)
 		return -4;
 	}
 
+	if(state.secure_state == SWITCHTEC_INITIALIZED_SECURED &&
+	   cfg.pubk_file == NULL) {
+		fprintf(stderr,
+			"Public key file must be specified when secure state is INITIALIZED_SECURED!\n");
+		return -4;
+	}
+	
 	if(cfg.pubk_file) {
 		ret = switchtec_read_pubk_file(cfg.pubk_fimg, pubk, &exponent);
 		fclose(cfg.pubk_fimg);
@@ -793,6 +800,13 @@ static int kmsk_add(int argc, char **argv)
 		}
 	}
 
+	if(state.secure_state == SWITCHTEC_INITIALIZED_SECURED &&
+	   cfg.sig_file == NULL) {
+		fprintf(stderr,
+			"Signature file must be specified when secure state is INITIALIZED_SECURED!\n");
+		return -5;
+	}
+	
 	if(cfg.sig_file) {
 		ret = load_sig_from_file(cfg.sig_fimg, sig);
 		fclose(cfg.sig_fimg);

--- a/cli/recovery.c
+++ b/cli/recovery.c
@@ -955,7 +955,9 @@ static int dport_unlock(int argc, char **argv)
 		unsigned long serial;
 		FILE *sig_fimg;
 		char *sig_file;
-	} cfg = {};
+	} cfg = {
+		.unlock_version = 0xffff,
+	};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
 		{"pub_key", 'p', .cfg_type=CFG_FILE_R,
@@ -976,9 +978,6 @@ static int dport_unlock(int argc, char **argv)
 			.help="signature file"},
 		{NULL}
 	};
-
-	cfg.serial = 0;
-	cfg.unlock_version = 0xffff;
 
 	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
 
@@ -1049,7 +1048,9 @@ static int dport_lock_update(int argc, char **argv)
 		FILE *sig_fimg;
 		char *sig_file;
 		unsigned int assume_yes;
-	} cfg = {};
+	} cfg = {
+		.unlock_version = 0xffff,
+	};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
 		{"pub_key", 'p', .cfg_type=CFG_FILE_R,
@@ -1072,9 +1073,6 @@ static int dport_lock_update(int argc, char **argv)
 			"assume yes when prompted"},
 		{NULL}
 	};
-
-	cfg.serial = 0;
-	cfg.unlock_version = 0xffff;
 
 	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
 


### PR DESCRIPTION
Added parameter checking for 'kmsk-entry-add', 'dport-unlock' and 'dport-lock-update' commands.