### PR TITLE
Secure boot latency ingress port 60 fix

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -561,7 +561,7 @@ static int latency(int argc, char **argv)
 	}
 
 	ret = switchtec_lat_setup(cfg.dev, cfg.egress, cfg.ingress, 1);
-	if (ret < 0) {
+	if (ret) {
 		switchtec_perror("latency");
 		return -1;
 	}


### PR DESCRIPTION
switchtec_lat_setup() could return a positive error code. Just check if return value is non-zero.