### PR TITLE
Fix evcntr-wait timeout segfault in Windows

### DIFF
--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -270,6 +270,9 @@ int gasop_event_summary(struct switchtec_dev *dev,
 	int i;
 	uint32_t reg;
 
+	if (!sum)
+		return 0;
+
 	memset(sum, 0, sizeof(*sum));
 
 	sum->global = gas_reg_read32(dev, sw_event.global_summary);

--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -873,7 +873,7 @@ static int linux_event_summary(struct switchtec_dev *dev,
 	struct switchtec_linux *ldev = to_switchtec_linux(dev);
 
 	if (!sum)
-		return -EINVAL;
+		return 0;
 
 	ret = ioctl(ldev->fd, SWITCHTEC_IOCTL_EVENT_SUMMARY, &isum);
 	if (!ret) {


### PR DESCRIPTION
The evcntr-wait command will segfault in Windows when the timeout expires. This is because switchtec_evcntr_wait() passes NULL to switchtec_event_wait_for()'s "res" parameter, which makes its way to gasop_event_summary(), which then tries to memset it.

This can be fixed by passing a switchtec_event_summary struct instead of NULL.