### PR TITLE
Fix gas read / write in Windows

### DIFF
--- a/cli/gas.c
+++ b/cli/gas.c
@@ -282,7 +282,7 @@ static int gas_dump(int argc, char **argv)
 
 	static struct {
 		struct switchtec_dev *dev;
-		int count;
+		size_t count;
 		int text;
 	} cfg = {};
 	const struct argconfig_options opts[] = {
@@ -404,7 +404,7 @@ static int gas_read(int argc, char **argv)
 	static struct {
 		struct switchtec_dev *dev;
 		unsigned long addr;
-		unsigned long count;
+		size_t count;
 		unsigned bytes;
 		unsigned print_style;
 	} cfg = {
@@ -414,7 +414,7 @@ static int gas_read(int argc, char **argv)
 	};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
-		{"addr", 'a', "ADDR", CFG_SIZE_SUFFIX, &cfg.addr, required_argument,
+		{"addr", 'a', "ADDR", CFG_LONG_SUFFIX, &cfg.addr, required_argument,
 		 "address to read"},
 		{"bytes", 'b', "NUM", CFG_POSITIVE, &cfg.bytes, required_argument,
 		 "number of bytes to read per access (default 4)"},
@@ -468,7 +468,7 @@ static int gas_write(int argc, char **argv)
 	};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
-		{"addr", 'a', "ADDR", CFG_SIZE_SUFFIX, &cfg.addr, required_argument,
+		{"addr", 'a', "ADDR", CFG_LONG_SUFFIX, &cfg.addr, required_argument,
 		 "address to write"},
 		{"bytes", 'b', "NUM", CFG_POSITIVE, &cfg.bytes, required_argument,
 		 "number of bytes to write (default 4)"},


### PR DESCRIPTION
gas read / write commands fail in Windows either silently or with error messages. This is because "CFG_SIZE_SUFFIX" is used as the argument type for address / count arguments, which parses them as 64-bit ssize_t types, but the variables are declared as 32-bit longs. The argument values are then parsed incorrectly.

The fix is to change the "count" variables to size_t types, and change address argument types back to CFG_LONG_SUFFIX as GAS addresses are always 32 bits.