### PR TITLE
Fix missing prompt output in Windows

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1104,6 +1104,7 @@ int ask_if_sure(int always_yes)
 		return 0;
 
 	fprintf(stderr, "Do you want to continue? [y/N] ");
+	fflush(stderr);
 	ret = fgets(buf, sizeof(buf), stdin);
 
 	if (!ret)


### PR DESCRIPTION
For commands that give a "Do you want to continue" prompt (e.g. fw-update, hard-reset, gas write), no output appears until after the user has entered something, so the user doesn't know that they're being prompted for anything.

This is fixed by flushing stderr after printing the prompt.