### PR TITLE
Switchtec cmd fix

### DIFF
--- a/lib/fw.c
+++ b/lib/fw.c
@@ -138,7 +138,7 @@ int switchtec_fw_dlstatus(struct switchtec_dev *dev,
 	ret = switchtec_cmd(dev, MRPC_FWDNLD, &subcmd, sizeof(subcmd),
 			    &result, sizeof(result));
 
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	if (status != NULL)
@@ -347,7 +347,7 @@ int switchtec_fw_write_fd(struct switchtec_dev *dev, int img_fd,
 		ret = switchtec_cmd(dev, MRPC_FWDNLD, &cmd, sizeof(cmd),
 				    NULL, 0);
 
-		if (ret < 0)
+		if (ret)
 			return ret;
 
 		ret = switchtec_fw_wait(dev, &status);
@@ -439,7 +439,7 @@ int switchtec_fw_write_file(struct switchtec_dev *dev, FILE *fimg,
 		ret = switchtec_cmd(dev, MRPC_FWDNLD, &cmd, sizeof(cmd),
 				    NULL, 0);
 
-		if (ret < 0)
+		if (ret)
 			return ret;
 
 		ret = switchtec_fw_wait(dev, &status);
@@ -896,7 +896,7 @@ static int switchtec_fw_part_info_gen4(struct switchtec_dev *dev,
 
 	ret = switchtec_cmd(dev, MRPC_PART_INFO, &subcmd, sizeof(subcmd),
 			    &all_info, sizeof(all_info));
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	switch(inf->part_id) {

--- a/lib/platform/platform.c
+++ b/lib/platform/platform.c
@@ -132,7 +132,7 @@ int switchtec_get_fw_version(struct switchtec_dev *dev, char *buf,
  * @param[in]  payload_len	Input data length (in bytes)
  * @param[out] resp		Output data
  * @param[in]  resp_len		Output data length (in bytes)
- * @return 0 on success, negative on failure
+ * @return 0 on success, negative on system error, positive on MRPC error
  */
 int switchtec_cmd(struct switchtec_dev *dev,  uint32_t cmd,
 		  const void *payload, size_t payload_len, void *resp,
@@ -144,7 +144,7 @@ int switchtec_cmd(struct switchtec_dev *dev,  uint32_t cmd,
 	cmd |= dev->pax_id << SWITCHTEC_PAX_ID_SHIFT;
 
 	ret = dev->ops->cmd(dev, cmd, payload, payload_len, resp, resp_len);
-	if (ret) {
+	if (ret > 0) {
 		mrpc_error_cmd = cmd & SWITCHTEC_CMD_MASK;
 		errno |= SWITCHTEC_ERRNO_MRPC_FLAG_BIT;
 	}


### PR DESCRIPTION
The switchtec_cmd() API returns zero on success, positive and negative value on errors, this was the original definition of it. As code changes, some of the rules become not so clear and there was some breaks in the code.

This patch series ensures that the return value of switchtec_cmd() be
1. zero on success
2. negative on system error with proper errno set
3. positive on MRPC error with proper mrpc_error_cmd/errno set

And it also fixed some the caller in the library to ensure all callers in the library check non-zero return of switchtec_cmd() for errors, rather then check negative value only.

