### PR TITLE
Fix fw-info command for BL2

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1270,6 +1270,7 @@ static int fw_info(int argc, char **argv)
 	const char *desc = "Test if switchtec interface is working";
 	int ret;
 	char version[64];
+	enum switchtec_boot_phase phase_id;
 
 	static struct {
 		struct switchtec_dev *dev;
@@ -1280,15 +1281,27 @@ static int fw_info(int argc, char **argv)
 
 	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
 
-	ret = switchtec_get_fw_version(cfg.dev, version, sizeof(version));
-	if (ret < 0) {
-		switchtec_perror("fw info");
+	ret = switchtec_get_device_info(cfg.dev, &phase_id, NULL, NULL);
+	if (ret) {
+		switchtec_perror("print fw info");
 		return ret;
 	}
+	if (phase_id == SWITCHTEC_BOOT_PHASE_BL1) {
+		fprintf(stderr,
+			"This command is only available in BL2 or Main Firmware!\n");
+		return -1;
+	}
+	if (phase_id == SWITCHTEC_BOOT_PHASE_FW) {
+		ret = switchtec_get_fw_version(cfg.dev, version,
+					       sizeof(version));
+		if (ret < 0) {
+			switchtec_perror("print fw info");
+			return ret;
+		}
 
-	printf("Currently Running:\n");
-	printf("  IMG\tVersion: %s\n", version);
-
+		printf("Currently Running:\n");
+		printf("  IMG\tVersion: %s\n", version);
+	}
 	ret = print_fw_part_info(cfg.dev);
 	if (ret) {
 		switchtec_perror("print fw info");

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -1177,8 +1177,8 @@ switchtec_fw_part_summary(struct switchtec_dev *dev)
 
 	ret = get_multicfg(dev, &summary->all[nr_info], &nr_mcfg);
 	if (ret) {
-		free(summary);
-		return NULL;
+		nr_mcfg = 0;
+		errno = 0;
 	}
 
 	for (i = 0; i < nr_info; i++) {


### PR DESCRIPTION
Command 'fw-info' is now only available in BL2 and Main FW boot phase, so we print an error when device is in BL1 phase. 

BL2's support of 'fw-info' has its limitations as well:
- does not support getting multicfg command
- does not support getting current running fw version

So we set multicfg to 0, and skip showing current running fw version in BL2.