### PR TITLE
Fix a reported bug in fw_toggle

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1390,6 +1390,7 @@ static int fw_toggle(int argc, char **argv)
 {
 	const char *desc = "Toggle active and inactive firmware partitions";
 	int ret = 0;
+	int err = 0;
 
 	static struct {
 		struct switchtec_dev *dev;
@@ -1425,11 +1426,16 @@ static int fw_toggle(int argc, char **argv)
 							   cfg.key,
 							   cfg.firmware,
 							   cfg.config);
+		err = errno;
 	}
 
-	print_fw_part_info(cfg.dev);
+	ret = print_fw_part_info(cfg.dev);
+	if (ret)
+		switchtec_perror("print fw info");
+
 	printf("\n");
 
+	errno = err;
 	switchtec_perror("firmware toggle");
 
 	return ret;

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -954,7 +954,7 @@ static int switchtec_fw_part_info_gen4(struct switchtec_dev *dev,
  * @param[in]  nr_info 	Number of partitions to retrieve the info for
  * @param[out] info	Pointer to a list of info structs of at least
  *	\p nr_info entries
- * @return 0 on success, error code on failure
+ * @return number of part info on success, negative on failure
  */
 static int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
 				  struct switchtec_fw_image_info *info)
@@ -1000,7 +1000,6 @@ static int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
 			return ret;
 
 		if (ret) {
-			errno = 0;
 			inf->version[0] = 0;
 			inf->image_crc = 0xFFFFFFFF;
 			inf->metadata = NULL;


### PR DESCRIPTION
In fw_toggle(), after the toggle operation, it will get fw info and display. In the case of a failed toggle operation, it is observed that the fw-toggle command still show suceess after the fw info display. 

The reason is that when get fw info, the switchtec_fw_part_info(), which is called when getting the fw info, will clear the errno in some cases when it ends up succeeded. This patch remove the errno clear code to make sure it's untouched on success return of the function. 