### PR TITLE
Add fw-type and secure version check to 'fw-update' command.

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1423,6 +1423,16 @@ static int fw_update(int argc, char **argv)
 	print_fw_part_info(cfg.dev);
 	printf("\n");
 
+	if (type == SWITCHTEC_FW_TYPE_MAP) {
+		printf("\nNOTE: Device partition map has been updated. Be sure to update\n"
+		       "all other partitions as well to ensure your device can boot properly.\n");
+	}
+
+	if (switchtec_boot_phase(cfg.dev) == SWITCHTEC_BOOT_PHASE_BL2 &&
+	    !cfg.dont_activate) {
+		printf("\nNOTE: This command does not automatically activate the image when used in BL2 boot phase.\n"
+		       "Be sure to use 'fw-toggle' after this command to activate the updated image.\n");
+	}
 set_boot_ro:
 	if (cfg.set_boot_rw)
 		switchtec_fw_set_boot_ro(cfg.dev, SWITCHTEC_FW_RO);

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -701,6 +701,8 @@ int switchtec_fw_read(struct switchtec_dev *dev, unsigned long addr,
 		      size_t len, void *buf);
 void switchtec_fw_perror(const char *s, int ret);
 int switchtec_fw_file_info(int fd, struct switchtec_fw_image_info *info);
+int switchtec_fw_file_secure_version_newer(struct switchtec_dev *dev,
+					   int img_fd);
 const char *switchtec_fw_image_type(const struct switchtec_fw_image_info *info);
 struct switchtec_fw_part_summary *
 switchtec_fw_part_summary(struct switchtec_dev *dev);

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -228,6 +228,8 @@ struct switchtec_fw_image_info {
 
 	struct switchtec_fw_image_info *next;
 	void *metadata;
+
+	unsigned long secure_version;
 };
 
 struct switchtec_fw_part_summary {

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -599,6 +599,8 @@ static int switchtec_fw_file_info_gen3(int fd,
 
 	info->type = switchtec_fw_id_to_type(info);
 
+	info->secure_version = 0;
+
 	return 0;
 
 invalid_file:
@@ -661,6 +663,7 @@ static int switchtec_fw_file_info_gen4(int fd,
 
 	info->type = switchtec_fw_id_to_type(info);
 
+	info->secure_version = le32toh(hdr.secure_version);
 	return 0;
 
 invalid_file:


### PR DESCRIPTION
Add the following checks in 'fw-update':
- FW secure version check: remind user that updating the image will update the chip secure version as well.
- FW type check: if partition map is updated, remind user to update all other partitions as well.
- Device boot phase check: if boot phase is BL2, remind user that the image is not automatically activated, be sure to use 'fw-toggle' to activate the image.