### PR TITLE
Fix 'fw-toggle' error in BL2 boot phase.

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1498,7 +1498,8 @@ static int fw_toggle(int argc, char **argv)
 							   cfg.key,
 							   cfg.firmware,
 							   cfg.config);
-		err = errno;
+		if (ret)
+			err = errno;
 	}
 
 	ret = print_fw_part_info(cfg.dev);


### PR DESCRIPTION
Command 'fw-toggle' in BL2 boot phase prints error from function 'switchtec_perror'. This is due to function 'switchtec_fw_toggle_active_partition' set _errno_ to non-zero even when it succeeds. Since the value in _errno_ is significant only when the return value of the call indicated an error, we should check ret code before saving the value of _errno_.

This is a continuation of PR 160: Fix i2c_gas_write_status_get() errno handling. The previous PR fixed the low-level function that changes _errno_. After discussion it seems a more appropriate fix should be done at the high-level _fw-toggle_ function.