### PR TITLE
Rename 'switchtec_security_cfg_stat' to 'switchtec_security_cfg_state'.

### DIFF
--- a/cli/mfg.c
+++ b/cli/mfg.c
@@ -104,7 +104,7 @@ static int ping(int argc, char **argv)
 	return 0;
 }
 
-static void print_security_config(struct switchtec_security_cfg_stat *state)
+static void print_security_config(struct switchtec_security_cfg_state *state)
 {
 	int key_idx;
 	int i;
@@ -211,7 +211,7 @@ static int info(int argc, char **argv)
 		{NULL}
 	};
 
-	struct switchtec_security_cfg_stat state = {};
+	struct switchtec_security_cfg_state state = {};
 
 	argconfig_parse(argc, argv, CMD_DESC_INFO, opts, &cfg, sizeof(cfg));
 
@@ -636,7 +636,7 @@ static int secure_state_set(int argc, char **argv)
 {
 	int ret;
 	enum switchtec_boot_phase phase_id;
-	struct switchtec_security_cfg_stat state = {};
+	struct switchtec_security_cfg_state state = {};
 
 	const char *desc = CMD_DESC_STATE_SET "\n\n"
 			   "This command can only be used when the device "
@@ -734,7 +734,7 @@ static int security_config_set(int argc, char **argv)
 {
 	int ret;
 	enum switchtec_boot_phase phase_id;
-	struct switchtec_security_cfg_stat state = {};
+	struct switchtec_security_cfg_state state = {};
 	struct switchtec_security_cfg_set settings = {};
 
 	static struct {
@@ -811,7 +811,7 @@ static int kmsk_entry_add(int argc, char **argv)
 	struct switchtec_kmsk kmsk;
 	struct switchtec_pubkey pubk;
 	struct switchtec_signature sig;
-	struct switchtec_security_cfg_stat state = {};
+	struct switchtec_security_cfg_state state = {};
 
 	const char *desc = CMD_DESC_KMSK_ENTRY_ADD "\n\n"
 			   "KMSK stands for Key Manifest Secure Key. It is a "

--- a/inc/switchtec/mfg.h
+++ b/inc/switchtec/mfg.h
@@ -65,7 +65,7 @@ enum switchtec_spi_clk_rate {
 	SWITCHTEC_SPI_RATE_18_18M
 };
 
-struct switchtec_security_cfg_stat {
+struct switchtec_security_cfg_state {
 	uint8_t basic_setting_valid;
 	uint8_t public_key_exp_valid;
 	uint8_t public_key_num_valid;
@@ -141,7 +141,7 @@ struct switchtec_signature{
 int switchtec_sn_ver_get(struct switchtec_dev *dev,
 			 struct switchtec_sn_ver_info *info);
 int switchtec_security_config_get(struct switchtec_dev *dev,
-			          struct switchtec_security_cfg_stat *state);
+			          struct switchtec_security_cfg_state *state);
 int switchtec_security_config_set(struct switchtec_dev *dev,
 				  struct switchtec_security_cfg_set *setting);
 int switchtec_mailbox_to_file(struct switchtec_dev *dev, int fd);
@@ -174,7 +174,7 @@ int switchtec_read_kmsk_file(FILE *kmsk_file, struct switchtec_kmsk *kmsk);
 int switchtec_read_signature_file(FILE *sig_file,
 				  struct switchtec_signature *sigature);
 int
-switchtec_security_state_has_kmsk(struct switchtec_security_cfg_stat *state,
+switchtec_security_state_has_kmsk(struct switchtec_security_cfg_state *state,
 				  struct switchtec_kmsk *kmsk);
 
 #endif // LIBSWITCHTEC_MFG_H

--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -121,7 +121,7 @@ int switchtec_sn_ver_get(struct switchtec_dev *dev,
  * @return 0 on success, error code on failure
  */
 int switchtec_security_config_get(struct switchtec_dev *dev,
-				  struct switchtec_security_cfg_stat *state)
+				  struct switchtec_security_cfg_state *state)
 {
 	int ret;
 	struct cfg_reply {
@@ -762,7 +762,7 @@ int switchtec_read_signature_file(FILE *sig_file,
  * @return 0 on success, error code on failure
  */
 int
-switchtec_security_state_has_kmsk(struct switchtec_security_cfg_stat *state,
+switchtec_security_state_has_kmsk(struct switchtec_security_cfg_state *state,
 				  struct switchtec_kmsk *kmsk)
 {
 	int key_idx;


### PR DESCRIPTION
No other code change.