### PR TITLE
Remove switchtec_fw_dlstatus and switchtec_fw_wait from public header.

### DIFF
--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -675,11 +675,6 @@ enum switchtec_fw_redundancy {
 	SWITCHTEC_FW_REDUNDANCY_CLEAR = 0,
 };
 
-int switchtec_fw_dlstatus(struct switchtec_dev *dev,
-			  enum switchtec_fw_dlstatus *status,
-			  enum mrpc_bg_status *bgstatus);
-int switchtec_fw_wait(struct switchtec_dev *dev,
-		      enum switchtec_fw_dlstatus *status);
 int switchtec_fw_toggle_active_partition(struct switchtec_dev *dev,
 					 int toggle_bl2, int toggle_key,
 					 int toggle_fw, int toggle_cfg);

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -117,16 +117,9 @@ struct switchtec_fw_image_header_gen3 {
 	uint32_t image_crc;
 };
 
-/**
- * @brief Perform an MRPC echo command
- * @param[in]  dev      Switchtec device handle
- * @param[out] status   The current download status
- * @param[out] bgstatus The current MRPC background status
- * @return 0 on success, error code on failure
- */
-int switchtec_fw_dlstatus(struct switchtec_dev *dev,
-			  enum switchtec_fw_dlstatus *status,
-			  enum mrpc_bg_status *bgstatus)
+static int switchtec_fw_dlstatus(struct switchtec_dev *dev,
+				 enum switchtec_fw_dlstatus *status,
+				 enum mrpc_bg_status *bgstatus)
 {
 	uint32_t cmd = MRPC_FWDNLD;
 	uint32_t subcmd = MRPC_FWDNLD_GET_STATUS;
@@ -155,17 +148,8 @@ int switchtec_fw_dlstatus(struct switchtec_dev *dev,
 	return 0;
 }
 
-/**
- * @brief Wait for a firmware download chunk to complete
- * @param[in]  dev      Switchtec device handle
- * @param[out] status   The current download status
- * @return 0 on success, error code on failure
- *
- * Polls the firmware download status waiting until it no longer
- * indicates it's INPROGRESS. Sleeps 5ms between each poll.
- */
-int switchtec_fw_wait(struct switchtec_dev *dev,
-		      enum switchtec_fw_dlstatus *status)
+static int switchtec_fw_wait(struct switchtec_dev *dev,
+			     enum switchtec_fw_dlstatus *status)
 {
 	enum mrpc_bg_status bgstatus;
 	int ret;


### PR DESCRIPTION
Make these functions local to fw.c file.

These functions are too specific for user to call directly.