### PR TITLE
Use 'i2c_gas_write_no_retry' for specific commands

### DIFF
--- a/lib/platform/linux-uart.c
+++ b/lib/platform/linux-uart.c
@@ -451,6 +451,7 @@ static const struct switchtec_ops uart_ops = {
 	.gas_write8 = uart_gas_write8,
 	.gas_write16 = uart_gas_write16,
 	.gas_write32 = uart_gas_write32,
+	.gas_write32_no_retry = uart_gas_write32,
 	.gas_write64 = uart_gas_write64,
 
 	.memcpy_to_gas = uart_memcpy_to_gas,

--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -982,6 +982,7 @@ static const struct switchtec_ops linux_ops = {
 	.gas_write8 = mmap_gas_write8,
 	.gas_write16 = mmap_gas_write16,
 	.gas_write32 = mmap_gas_write32,
+	.gas_write32_no_retry = mmap_gas_write32,
 	.gas_write64 = mmap_gas_write64,
 	.memcpy_to_gas = mmap_memcpy_to_gas,
 	.memcpy_from_gas = mmap_memcpy_from_gas,

--- a/lib/platform/windows.c
+++ b/lib/platform/windows.c
@@ -443,6 +443,7 @@ static const struct switchtec_ops windows_ops = {
 	.gas_write8 = mmap_gas_write8,
 	.gas_write16 = mmap_gas_write16,
 	.gas_write32 = mmap_gas_write32,
+	.gas_write32_no_retry = mmap_gas_write32,
 	.gas_write64 = mmap_gas_write64,
 	.memcpy_to_gas = mmap_memcpy_to_gas,
 	.memcpy_from_gas = mmap_memcpy_from_gas,

--- a/lib/switchtec_priv.h
+++ b/lib/switchtec_priv.h
@@ -108,6 +108,8 @@ struct switchtec_ops {
 			    uint16_t __gas *addr);
 	void (*gas_write32)(struct switchtec_dev *dev, uint32_t val,
 			    uint32_t __gas *addr);
+	void (*gas_write32_no_retry)(struct switchtec_dev *dev, uint32_t val,
+				     uint32_t __gas *addr);
 	void (*gas_write64)(struct switchtec_dev *dev, uint64_t val,
 			    uint64_t __gas *addr);
 
@@ -190,6 +192,13 @@ static inline void __gas_write32(struct switchtec_dev *dev, uint32_t val,
 				 uint32_t __gas *addr)
 {
 	dev->ops->gas_write32(dev, val, addr);
+}
+
+static inline void __gas_write32_no_retry(struct switchtec_dev *dev,
+					  uint32_t val,
+					  uint32_t __gas *addr)
+{
+	dev->ops->gas_write32_no_retry(dev, val, addr);
 }
 
 static inline void __gas_write64(struct switchtec_dev *dev, uint64_t val,


### PR DESCRIPTION
Due to the unreliable nature of I2C communication, function i2c_gas_write() is implemented with automatic retry (100 times). 

This poses a potential issue when a command is critical and expected to be sent only once (e.g., commands that adds a KMSK entry to chip OTP memory). Retrying could cause the command be sent multiple times (and multiple KMSK entry being added, if unlucky).

Some background information: an MRPC command consists of command ID and command data. To send an MRPC command, we send command data first, then send the command ID. Sending command ID triggers execution of the command on the firmware side.

At the moment we can think of 2 ways to fix this:
- We notice that in gasop_cmd() function, the command data is sent using __memcpy_to_gas(), and the command ID is sent using __gas_write32(). So we take out the retry in i2c_gas_write32() function. This is the code committed in this PR. This fix is ad-hoc, and will have impact on other functions that call __gas_write32().
- In i2c_gas_write() function, we check the address of the write, if it's writing to the command ID address, then we do not use retry. This fix is ad-hoc too, but it does not impact other functions that write data to GAS.

Other suggestions are welcome.