### PR TITLE
Windows MinGW build fix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -62,8 +62,8 @@ ifeq ($(findstring mingw,$(MACHINE)),mingw)
   SHLIBNAME ?= switchtec.dll
   IMPLIBNAME ?= libswitchtec.dll.a
   override LDFLAGS += -Wl,--out-implib,$(IMPLIBNAME)
-  SHLDLIBS = -lsetupapi
-  LDLIBS += -lsetupapi
+  LDLIBS += -lsetupapi -lws2_32
+  SHLDLIBS = $(LDLIBS)
   LDCONFIG=
   override CPPFLAGS += -DNTDDI_VERSION=NTDDI_VISTA -D_WIN32_WINNT=_WIN32_WINNT_VISTA
 else


### PR DESCRIPTION
If libcrypto is present, GCC needs crypto and ws2_32 library to build the shared switchtec.dll library in Windows MinGW.