### PR TITLE
Change submenu availability

### DIFF
--- a/cli/common.h
+++ b/cli/common.h
@@ -28,6 +28,8 @@
 int ask_if_sure(int always_yes);
 int switchtec_handler(const char *optarg, void *value_addr,
 		      const struct argconfig_options *opt);
+int mfg_handler(const char *optarg, void *value_addr,
+		const struct argconfig_options *opt);
 int pax_handler(const char *optarg, void *value_addr,
 		const struct argconfig_options *opt);
 enum switchtec_fw_type check_and_print_fw_image(int img_fd,
@@ -52,11 +54,11 @@ enum switchtec_fw_type check_and_print_fw_image(int img_fd,
 
 #define UART_HELP_TEXT " * a UART path (/dev/ttyUSB0)\n"
 
-#define DEVICE_OPTION_BASIC(extra_text) \
+#define DEVICE_OPTION_BASIC(extra_text, handler) \
 	{ \
 			"device", .cfg_type=CFG_CUSTOM, .value_addr=&cfg.dev, \
 			.argument_type=required_positional, \
-			.custom_handler=switchtec_handler, \
+			.custom_handler=handler, \
 			.complete="/dev/switchtec*", \
 			.env="SWITCHTEC_DEV", \
 			.help="Switchtec device to operate on. Can be any of:\n" \
@@ -67,9 +69,9 @@ enum switchtec_fw_type check_and_print_fw_image(int img_fd,
 			extra_text \
 	}
 
-#define DEVICE_OPTION_MFG DEVICE_OPTION_BASIC()
+#define DEVICE_OPTION_MFG DEVICE_OPTION_BASIC(, mfg_handler)
 
-#define DEVICE_OPTION DEVICE_OPTION_BASIC(UART_HELP_TEXT), \
+#define DEVICE_OPTION DEVICE_OPTION_BASIC(UART_HELP_TEXT, switchtec_handler), \
 	{ \
 			"pax", 'x', .cfg_type=CFG_CUSTOM, \
 			.value_addr=&cfg.dev, \

--- a/cli/main.c
+++ b/cli/main.c
@@ -90,6 +90,25 @@ int switchtec_handler(const char *optarg, void *value_addr,
 	return 0;
 }
 
+/*
+ * The 'mfg' submenu commands are only available in Linux builds.
+ *
+ * Due to the difference in driver architecture, supporting Windows
+ * build is non-trivial. After evaluating the development effort
+ * and the resources available, we have decided to remove Windows
+ * build support from release roadmap.
+ * 
+ */
+int mfg_handler(const char *optarg, void *value_addr,
+		const struct argconfig_options *opt)
+{
+#ifndef __linux__
+	printf("WARNING: MFG COMMANDS ARE NOT SUPPORTED ON YOUR CURRENT OPERATING SYSTEM!\n"
+	       "Use this command at your own risk!!!\n\n\n");
+#endif
+	return switchtec_handler(optarg, value_addr, opt);
+}
+
 int pax_handler(const char *optarg, void *value_addr,
 		const struct argconfig_options *opt)
 {


### PR DESCRIPTION
Make the following changes to submenu availability:
- 'mfg' is only available in Linux build
- 'fabric' is not available by default. Only available in Linux build, when configured with '--with-fabric' option. 