### PR TITLE
Fix MRPC errors found on secured devices

### DIFF
--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -123,6 +123,11 @@ int gasop_cmd(struct switchtec_dev *dev, uint32_t cmd,
 		return -errno;
 	}
 
+	if(status == SWITCHTEC_MRPC_STATUS_ERROR) {
+		errno = __gas_read32(dev, &mrpc->ret_value);
+		return errno;
+	}
+
 	if (status != SWITCHTEC_MRPC_STATUS_DONE) {
 		errno = ENXIO;
 		return -errno;

--- a/lib/platform/platform.c
+++ b/lib/platform/platform.c
@@ -115,12 +115,7 @@ int switchtec_list(struct switchtec_device_info **devlist);
 int switchtec_get_fw_version(struct switchtec_dev *dev, char *buf,
 			     size_t buflen)
 {
-	int fw_ver;
-
-	fw_ver = gas_mrpc_read32(dev, &dev->gas_map->sys_info.firmware_version);
-	version_to_string(fw_ver, buf, buflen);
-
-	return 0;
+	return dev->ops->get_fw_version(dev, buf, buflen);
 }
 
 /**


### PR DESCRIPTION
Two issues were found on secured devices:
- 'switchtec_get_fw_version' fails when MRPC_GAS_READ command is whitelisted
- The error code displayed does not reflect the true error condition

These two issues are fixed in the 2 commits in this PR. Details are explained in the commit messages.