### PR TITLE
Add reading error code when IB driver returns EIO.

### DIFF
--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -329,9 +329,13 @@ static int read_resp(struct switchtec_linux *ldev, void *resp,
 
 	ret = read(ldev->fd, buf, bufsize);
 
-	if (ret < 0)
+	if (ret < 0) {
+		if (errno == EIO) {
+			memcpy(&ret, buf, sizeof(ret));
+			errno = ret;
+		}
 		return ret;
-
+	}
 	if (ret != bufsize) {
 		errno = EIO;
 		return -errno;


### PR DESCRIPTION
When IB driver returns EIO after executing an MRPC command, an error code is also returned in the return buffer. This error code is read and returned to upper layer.

This PR should be reviewed along with switchtec-kernel PR #86