### PR TITLE
Fix 'kmsk-entry-add' command parameter checking

### DIFF
--- a/cli/mfg.c
+++ b/cli/mfg.c
@@ -938,7 +938,7 @@ static int kmsk_entry_add(int argc, char **argv)
 	if (ret)
 		return -7;
 
-	if (cfg.pubk_file && cfg.sig_file) {
+	if (state.secure_state == SWITCHTEC_INITIALIZED_SECURED) {
 		ret = switchtec_kmsk_set(cfg.dev, &pubk, &sig, &kmsk);
 
 	}


### PR DESCRIPTION
Instead of checking if the parameters are supplied by user, we use current secure state to decide if we need to send public key and signature data.