### PR TITLE
Fix "make install" on MSYS2

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -57,6 +57,10 @@ STLIBNAME ?= libswitchtec.a
 MACHINE=$(shell $(CC) -dumpmachine)
 
 ifeq ($(findstring mingw,$(MACHINE)),mingw)
+  MINGW := YES
+endif
+
+ifeq ($(MINGW), YES)
   EXENAME ?= switchtec.exe
   INSTEXENAME ?= switchtec
   SHLIBNAME ?= switchtec.dll
@@ -64,7 +68,6 @@ ifeq ($(findstring mingw,$(MACHINE)),mingw)
   override LDFLAGS += -Wl,--out-implib,$(IMPLIBNAME)
   LDLIBS += -lsetupapi -lws2_32
   SHLDLIBS = $(LDLIBS)
-  LDCONFIG=
   override CPPFLAGS += -DNTDDI_VERSION=NTDDI_VISTA -D_WIN32_WINNT=_WIN32_WINNT_VISTA
 else
   EXENAME ?= switchtec
@@ -150,8 +153,10 @@ install-bin: compile
 	$(Q)install -m 0664 $(STLIBNAME) $(LIBDIR)
 	@$(NQ) echo "  INSTALL  $(LIBDIR)/$(IMPLIBNAME).$(VERSION)"
 	$(Q)install $(IMPLIBNAME) $(LIBDIR)/$(IMPLIBNAME).$(VERSION)
+ifneq ($(MINGW), YES)
 	@$(NQ) echo "  INSTALL  $(LIBDIR)/$(IMPLIBNAME)"
 	$(Q)ln -fs $(IMPLIBNAME).$(MAJOR_VER) $(LIBDIR)/$(IMPLIBNAME)
+endif
 	@$(NQ) echo "  INSTALL  $(INCDIR)/switchtec"
 	@$(Q)mkdir -p $(INCDIR)
 	@$(Q)cp -r inc/switchtec $(INCDIR)
@@ -159,12 +164,16 @@ install-bin: compile
 install-pkg: install-bin install-bash-completion
 
 install: install-bin install-bash-completion
+ifneq ($(MINGW), YES)
 	@$(NQ) echo "  LDCONFIG"
 	$(Q)$(LDCONFIG) $(LIBDIR)
+endif
 
 uninstall:
+ifneq ($(MINGW), YES)
 	@$(NQ) echo "  LDCONFIG"
 	$(Q)$(LDCONFIG) $(LIBDIR)
+endif
 
 switchtec.spec: switchtec.spec.in $(OBJDIR)/version.mk
 	sed -e 's/@@VERSION@@/$(VERSION)/g' < $< | sed -e 's/@@RELEASE@@/$(RELEASE)/g' > $@+


### PR DESCRIPTION
"make install" fails in an MSYS2 environment, complaining that it can't create the symlink "/usr/local/lib/libswitchtec.dll.a". This is because the source of the symlink doesn't exist, and since MSYS2 just creates copies instead of symlinks, the copy fails.

Additionally, the install/uninstall Makefile targets run ldconfig commands. $LDCONFIG isn't defined in MSYS2 as ldconfig isn't supported, so these commands fail.

The symlink creation is now only done in a non-MinGW environment, as are the ldconfig commands.