### PR TITLE
Add EP BAR write command

### DIFF
--- a/inc/switchtec/fabric.h
+++ b/inc/switchtec/fabric.h
@@ -639,6 +639,7 @@ int switchtec_ep_tunnel_status(struct switchtec_dev *dev, uint16_t pdfid,
 #define SWITCHTEC_EP_CSR_MAX_READ_LEN  4
 #define SWITCHTEC_EP_CSR_MAX_WRITE_LEN 4
 #define SWITCHTEC_EP_BAR_MAX_READ_LEN  SWITCHTEC_MRPC_PAYLOAD_SIZE
+#define SWITCHTEC_EP_BAR_MAX_WRITE_LEN 128
 
 int switchtec_ep_csr_read8(struct switchtec_dev *dev, uint16_t pdfid,
 			   uint16_t addr, uint8_t *val);
@@ -660,6 +661,13 @@ int switchtec_ep_bar_read16(struct switchtec_dev *dev, uint16_t pdfid,
 			    uint8_t bar_index, uint64_t addr, uint16_t *val);
 int switchtec_ep_bar_read32(struct switchtec_dev *dev, uint16_t pdfid,
 			    uint8_t bar_index, uint64_t addr, uint32_t *val);
+
+int switchtec_ep_bar_write8(struct switchtec_dev *dev, uint16_t pdfid,
+			    uint8_t bar_index, uint8_t val, uint64_t addr);
+int switchtec_ep_bar_write16(struct switchtec_dev *dev, uint16_t pdfid,
+			     uint8_t bar_index, uint16_t val, uint64_t addr);
+int switchtec_ep_bar_write32(struct switchtec_dev *dev, uint16_t pdfid,
+			     uint8_t bar_index, uint32_t val, uint64_t addr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This command is used to write to the PCIe memory of an endpoint device.