### PR TITLE
Enable 64-bit BAR address read/write

### DIFF
--- a/cli/argconfig.c
+++ b/cli/argconfig.c
@@ -470,6 +470,23 @@ static int cfg_long_suffix_handler(const char *optarg, void *value_addr,
 	return 0;
 }
 
+static int cfg_long_long_handler(const char *optarg, void *value_addr,
+				 const struct argconfig_options *opt)
+{
+	char *endptr;
+
+	*((unsigned long long *)value_addr) = strtoull(optarg, &endptr, 0);
+	if (errno || optarg == endptr) {
+		fprintf(stderr,
+			"Expected long long integer argument for '--%s/-%c' "
+			"but got '%s'!\n",
+			opt->option, opt->short_option, optarg);
+		return 1;
+	}
+
+	return 0;
+}
+
 static int cfg_double_handler(const char *optarg, void *value_addr,
 			      const struct argconfig_options *opt)
 {
@@ -758,6 +775,7 @@ static type_handler cfg_type_handlers[_CFG_MAX_TYPES] = {
 	[CFG_SIZE_SUFFIX] = cfg_size_suffix_handler,
 	[CFG_LONG] = cfg_long_handler,
 	[CFG_LONG_SUFFIX] = cfg_long_suffix_handler,
+	[CFG_LONG_LONG] = cfg_long_long_handler,
 	[CFG_DOUBLE] = cfg_double_handler,
 	[CFG_BOOL] = cfg_bool_handler,
 	[CFG_BYTE] = cfg_byte_handler,

--- a/cli/argconfig.h
+++ b/cli/argconfig.h
@@ -54,6 +54,7 @@ enum argconfig_types {
 	CFG_SIZE_SUFFIX,
 	CFG_LONG,
 	CFG_LONG_SUFFIX,
+	CFG_LONG_LONG,
 	CFG_DOUBLE,
 	CFG_BOOL,
 	CFG_BYTE,

--- a/cli/fabric.c
+++ b/cli/fabric.c
@@ -1707,8 +1707,8 @@ static int ep_csr_write(int argc, char **argv)
 static int ep_bar_read(int argc, char **argv)
 {
 	unsigned long long val;
-	unsigned long addr;
-	unsigned bytes;
+	unsigned long long addr;
+	unsigned long long bytes;
 	int i;
 	int ret = 0;
 
@@ -1723,7 +1723,7 @@ static int ep_bar_read(int argc, char **argv)
 		struct switchtec_dev *dev;
 		unsigned short pdfid;
 		unsigned short bar;
-		unsigned long addr;
+		unsigned long long addr;
 		unsigned count;
 		unsigned bytes;
 		unsigned print_style;
@@ -1742,7 +1742,7 @@ static int ep_bar_read(int argc, char **argv)
 			required_argument, "pdfid of EP"},
 		{"bar", 'i', "BAR", CFG_SHORT, &cfg.bar,
 			required_argument, "BAR of EP"},
-		{"addr", 'a', "ADDR", CFG_LONG, &cfg.addr,
+		{"addr", 'a', "ADDR", CFG_LONG_LONG, &cfg.addr,
 			required_argument, "address to read"},
 		{"bytes", 'b', "NUM", CFG_POSITIVE, &cfg.bytes,
 			required_argument,
@@ -1824,7 +1824,7 @@ static int ep_bar_write(int argc, char **argv)
 		struct switchtec_dev *dev;
 		unsigned short pdfid;
 		unsigned short bar;
-		unsigned long addr;
+		unsigned long long addr;
 		unsigned bytes;
 		unsigned long value;
 		int assume_yes;
@@ -1840,7 +1840,7 @@ static int ep_bar_write(int argc, char **argv)
 			required_argument, "pdfid of EP"},
 		{"bar", 'i', "BAR", CFG_SHORT, &cfg.bar,
 			required_argument, "BAR of EP"},
-		{"addr", 'a', "ADDR", CFG_LONG, &cfg.addr,
+		{"addr", 'a', "ADDR", CFG_LONG_LONG, &cfg.addr,
 			required_argument, "address to write"},
 		{"bytes", 'b', "NUM", CFG_POSITIVE, &cfg.bytes,
 			required_argument,
@@ -1872,7 +1872,7 @@ static int ep_bar_write(int argc, char **argv)
 	}
 
 	if (!cfg.assume_yes)
-		fprintf(stderr, "Writing 0x%lx to %06lx (%d bytes).\n",
+		fprintf(stderr, "Writing 0x%lx to 0x%llx (%d bytes).\n",
 			cfg.value, cfg.addr, cfg.bytes);
 
 	ret = ask_if_sure(cfg.assume_yes);


### PR DESCRIPTION
Existing `CFG_LONG` type cannot handle 64-bit BAR address. 

Add `CFG_LONG_LONG` type to enable parsing 64-bit address used in command argument.