### PR TITLE
Fix "info" command for Gen3 devices on Windows

### DIFF
--- a/lib/fw.c
+++ b/lib/fw.c
@@ -1260,6 +1260,10 @@ switchtec_fw_part_summary(struct switchtec_dev *dev)
 
 	for (i = 0; i < nr_info; i++) {
 		type = switchtec_fw_type_ptr(summary, &summary->all[i]);
+		if (type == NULL) {
+			free(summary);
+			return NULL;
+		}
 		if (summary->all[i].active)
 			type->active = &summary->all[i];
 		else

--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -252,7 +252,8 @@ int gasop_flash_part(struct switchtec_dev *dev,
 	uint32_t active_addr = -1;
 	int val;
 
-	memset(info, 0, sizeof(*info));
+	info->running = false;
+	info->active = false;
 
 	switch (part) {
 	case SWITCHTEC_FW_PART_ID_G3_IMG0:


### PR DESCRIPTION
The "info" command causes a segfault on Windows when used with a Gen3 device. This is because  switchtec_fw_part_summary() calls switchtec_fw_part_info(), which sets inf->type and then passes inf to switchtec_fw_part_info_gen3(). This leads to a call to gasop_flash_part(), which clears the entire inf struct. Then switchtec_fw_part_summary() calls switchtec_fw_type_ptr(), which returns NULL since inf->type is now 0. switchtec_fw_part_summary() then tries to dereference the returned NULL pointer.

This is fixed by not clearing the inf struct in gasop_flash_part() as this is unnecessary and clobbers some previously-set elements. Also a NULL check has been added to switchtec_fw_part_summary() before using switchtec_fw_type_ptr()'s returned pointer.