### PR TITLE
Fix "fw-info" command for Gen3 devices on Windows

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1393,11 +1393,7 @@ static int fw_info(int argc, char **argv)
 
 	argconfig_parse(argc, argv, CMD_DESC_FW_INFO, opts, &cfg, sizeof(cfg));
 
-	ret = switchtec_get_device_info(cfg.dev, &phase_id, NULL, NULL);
-	if (ret) {
-		switchtec_perror("print fw info");
-		return ret;
-	}
+	phase_id = switchtec_boot_phase(cfg.dev);
 	if (phase_id == SWITCHTEC_BOOT_PHASE_BL1) {
 		fprintf(stderr,
 			"This command is only available in BL2 or Main Firmware!\n");


### PR DESCRIPTION
Running the "fw-info" command in Windows for a Gen3 device gives the error "A device attached to the system is not functioning." This is because the MRPC_GET_DEV_INFO command is being issued but the command isn't supported by Gen3 firmware. switchtec_get_device_info() attempts to account for this by checking for ERR_MPRC_UNSUPPORTED, but the MRPC return value isn't available when the MRPC status indicates failure.

This is fixed by checking for a Gen3 device in switchtec_get_device_info() rather than relying on the MRPC command being unsupported.