### PR TITLE
Fix GAS dump when some regions are inaccessible

### DIFF
--- a/cli/gas.c
+++ b/cli/gas.c
@@ -325,18 +325,27 @@ static int read_gas(struct switchtec_dev *dev, void __gas *addr,
 {
 	int ret = 0;
 
+	uint8_t u8;
+	uint16_t u16;
+	uint32_t u32;
+	uint64_t u64;
+
 	switch (bytes) {
 	case 1:
-		*val = gas_read8(dev, addr);
+		ret = gas_read8(dev, addr, &u8);
+		*val = u8;
 		break;
 	case 2:
-		*val = gas_read16(dev, addr);
+		ret = gas_read16(dev, addr, &u16);
+		*val = u16;
 		break;
 	case 4:
-		*val = gas_read32(dev, addr);
+		ret = gas_read32(dev, addr, &u32);
+		*val = u32;
 		break;
 	case 8:
-		*val = gas_read64(dev, addr);
+		ret = gas_read64(dev, addr, &u64);
+		*val = u64;
 		break;
 	default:
 		errno = EINVAL;

--- a/cli/gas.c
+++ b/cli/gas.c
@@ -36,7 +36,7 @@
 #include <errno.h>
 #include <ctype.h>
 
-static void print_line(unsigned long addr, uint8_t *bytes, size_t n)
+static void print_line(unsigned long addr, uint8_t *bytes, size_t n, int error)
 {
 	int i;
 
@@ -44,7 +44,11 @@ static void print_line(unsigned long addr, uint8_t *bytes, size_t n)
 	for (i = 0; i < n; i++) {
 		if (i == 8)
 			printf(" ");
-		printf(" %02x", bytes[i]);
+
+		if (error)
+			printf(" XX");
+		else
+			printf(" %02x", bytes[i]);
 	}
 
 	for (; i < 16; i++) {
@@ -54,7 +58,9 @@ static void print_line(unsigned long addr, uint8_t *bytes, size_t n)
 	printf("  |");
 
 	for (i = 0; i < 16; i++) {
-		if (isprint(bytes[i]))
+		if (error)
+			printf("X");
+		else if (isprint(bytes[i]))
 			printf("%c", bytes[i]);
 		else
 			printf(".");
@@ -86,7 +92,7 @@ static void hexdump_data(struct switchtec_dev *dev, void __gas *map,
 
 		if (bytes != sizeof(line) ||
 		    memcmp(last_line, line, sizeof(last_line))) {
-			print_line(addr, line, bytes);
+			print_line(addr, line, bytes, err);
 			last_match = 0;
 		} else if (!last_match) {
 			printf("*\n");

--- a/inc/switchtec/gas.h
+++ b/inc/switchtec/gas.h
@@ -66,9 +66,9 @@
 
 void memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
 		   const void *src, size_t n);
-
-void memcpy_from_gas(struct switchtec_dev *dev, void *dest,
-		     const void __gas *src, size_t n);
+__attribute__((warn_unused_result))
+int memcpy_from_gas(struct switchtec_dev *dev, void *dest,
+		    const void __gas *src, size_t n);
 
 ssize_t write_from_gas(struct switchtec_dev *dev, int fd,
 		       const void __gas *src, size_t n);

--- a/inc/switchtec/gas.h
+++ b/inc/switchtec/gas.h
@@ -73,10 +73,14 @@ void memcpy_from_gas(struct switchtec_dev *dev, void *dest,
 ssize_t write_from_gas(struct switchtec_dev *dev, int fd,
 		       const void __gas *src, size_t n);
 
-uint8_t gas_read8(struct switchtec_dev *dev, uint8_t __gas *addr);
-uint16_t gas_read16(struct switchtec_dev *dev, uint16_t __gas *addr);
-uint32_t gas_read32(struct switchtec_dev *dev, uint32_t __gas *addr);
-uint64_t gas_read64(struct switchtec_dev *dev, uint64_t __gas *addr);
+__attribute__((warn_unused_result))
+int gas_read8(struct switchtec_dev *dev, uint8_t __gas *addr, uint8_t *val);
+__attribute__((warn_unused_result))
+int gas_read16(struct switchtec_dev *dev, uint16_t __gas *addr, uint16_t *val);
+__attribute__((warn_unused_result))
+int gas_read32(struct switchtec_dev *dev, uint32_t __gas *addr, uint32_t *val);
+__attribute__((warn_unused_result))
+int gas_read64(struct switchtec_dev *dev, uint64_t __gas *addr, uint64_t *val);
 
 void gas_write8(struct switchtec_dev *dev, uint8_t val, uint8_t __gas *addr);
 void gas_write16(struct switchtec_dev *dev, uint16_t val,

--- a/inc/switchtec/gas_mrpc.h
+++ b/inc/switchtec/gas_mrpc.h
@@ -53,12 +53,15 @@ static inline uint8_t le8toh(uint8_t x) { return x; }
 static inline uint8_t htole8(uint8_t x) { return x; }
 
 #define create_mrpc_gas_read(type, suffix) \
-	static inline type gas_mrpc_read ## suffix(struct switchtec_dev *dev, \
-						   type __gas *addr) \
+	static inline int gas_mrpc_read ## suffix(struct switchtec_dev *dev, \
+						  type __gas *addr, \
+						  type *data) \
 	{ \
-		type ret; \
-		gas_mrpc_memcpy_from_gas(dev, &ret, addr, sizeof(ret)); \
-		return le##suffix##toh(ret);                            \
+		int ret; \
+		ret = gas_mrpc_memcpy_from_gas(dev, data, addr, \
+					       sizeof(type)); \
+		*data = le##suffix##toh(*data); \
+		return ret; \
 	}
 
 #define create_mrpc_gas_write(type, suffix) \

--- a/inc/switchtec/gas_mrpc.h
+++ b/inc/switchtec/gas_mrpc.h
@@ -43,8 +43,8 @@ struct gas_mrpc_read {
 
 void gas_mrpc_memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
 			    const void *src, size_t n);
-void gas_mrpc_memcpy_from_gas(struct switchtec_dev *dev, void *dest,
-			      const void __gas *src, size_t n);
+int gas_mrpc_memcpy_from_gas(struct switchtec_dev *dev, void *dest,
+			     const void __gas *src, size_t n);
 ssize_t gas_mrpc_write_from_gas(struct switchtec_dev *dev, int fd,
 				const void __gas *src, size_t n);
 

--- a/lib/gas_mrpc.c
+++ b/lib/gas_mrpc.c
@@ -87,9 +87,10 @@ void gas_mrpc_memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
  * @param[out] dest	Destination buffer
  * @param[in]  src	Source gas address
  * @param[in]  n	Number of bytes to transfer
+ * @return 0 on success, error code on failure
  */
-void gas_mrpc_memcpy_from_gas(struct switchtec_dev *dev, void *dest,
-			      const void __gas *src, size_t n)
+int gas_mrpc_memcpy_from_gas(struct switchtec_dev *dev, void *dest,
+			     const void __gas *src, size_t n)
 {
 	struct gas_mrpc_read cmd;
 	int ret;
@@ -105,12 +106,16 @@ void gas_mrpc_memcpy_from_gas(struct switchtec_dev *dev, void *dest,
 
 		ret = switchtec_cmd(dev, MRPC_GAS_READ, &cmd,
 				    sizeof(cmd), dest, len);
-		if (ret)
-			raise(SIGBUS);
+		if (ret) {
+			memset(dest, 0xff, n);
+			return ret;
+		}
 
 		n -= len;
 		dest += len;
 	}
+
+	return 0;
 }
 
 /**

--- a/lib/platform/platform.c
+++ b/lib/platform/platform.c
@@ -340,56 +340,68 @@ int switchtec_event_wait(struct switchtec_dev *dev, int timeout_ms)
  * @brief Read a uint8_t from the GAS
  * @param[in] dev	Switchtec device handle
  * @param[in] addr	Address to read the value
- * @return The read value
+ * @param[out] val	Data read from GAS
+ * @return 0 on success, error code on failure
  */
-uint8_t gas_read8(struct switchtec_dev *dev, uint8_t __gas *addr)
+int gas_read8(struct switchtec_dev *dev, uint8_t __gas *addr, uint8_t *val)
 {
 	if (dev->pax_id != dev->local_pax_id)
-		return gas_mrpc_read8(dev, addr);
+		return gas_mrpc_read8(dev, addr, val);
 	else
-		return __gas_read8(dev, addr);
+		*val = __gas_read8(dev, addr);
+
+	return 0;
 }
 
 /**
  * @brief Read a uint16_t from the GAS
  * @param[in] dev	Switchtec device handle
  * @param[in] addr	Address to read the value
- * @return The read value
+ * @param[out] val	Data read from GAS
+ * @return 0 on success, error code on failure
  */
-uint16_t gas_read16(struct switchtec_dev *dev, uint16_t __gas *addr)
+int gas_read16(struct switchtec_dev *dev, uint16_t __gas *addr, uint16_t *val)
 {
 	if (dev->pax_id != dev->local_pax_id)
-		return gas_mrpc_read16(dev, addr);
+		return gas_mrpc_read16(dev, addr, val);
 	else
-		return __gas_read16(dev, addr);
+		*val = __gas_read16(dev, addr);
+
+	return 0;
 }
 
 /**
  * @brief Read a uint32_t from the GAS
  * @param[in] dev	Switchtec device handle
  * @param[in] addr	Address to read the value
- * @return The read value
+ * @param[out] val	Data read from GAS
+ * @return 0 on success, error code on failure
  */
-uint32_t gas_read32(struct switchtec_dev *dev, uint32_t __gas *addr)
+int gas_read32(struct switchtec_dev *dev, uint32_t __gas *addr, uint32_t *val)
 {
 	if (dev->pax_id != dev->local_pax_id)
-		return gas_mrpc_read32(dev, addr);
+		return gas_mrpc_read32(dev, addr, val);
 	else
-		return __gas_read32(dev, addr);
+		*val = __gas_read32(dev, addr);
+
+	return 0;
 }
 
 /**
  * @brief Read a uint64_t from the GAS
  * @param[in] dev	Switchtec device handle
  * @param[in] addr	Address to read the value
- * @return The read value
+ * @param[out] val	Data read from GAS
+ * @return 0 on success, error code on failure
  */
-uint64_t gas_read64(struct switchtec_dev *dev, uint64_t __gas *addr)
+int gas_read64(struct switchtec_dev *dev, uint64_t __gas *addr, uint64_t *val)
 {
 	if (dev->pax_id != dev->local_pax_id)
-		return gas_mrpc_read64(dev, addr);
+		return gas_mrpc_read64(dev, addr, val);
 	else
-		return __gas_read64(dev, addr);
+		*val = __gas_read64(dev, addr);
+
+	return 0;
 }
 
 /**

--- a/lib/platform/platform.c
+++ b/lib/platform/platform.c
@@ -482,14 +482,17 @@ void memcpy_to_gas(struct switchtec_dev *dev, void __gas *dest,
  * @param[out] dest     Destination buffer
  * @param[in]  src      Source gas address
  * @param[in]  n        Number of bytes to transfer
+ * @return 0 on success, error code on failure
  */
-void memcpy_from_gas(struct switchtec_dev *dev, void *dest,
-		     const void __gas *src, size_t n)
+int memcpy_from_gas(struct switchtec_dev *dev, void *dest,
+		    const void __gas *src, size_t n)
 {
 	if (dev->pax_id != dev->local_pax_id)
-		gas_mrpc_memcpy_from_gas(dev, dest, src, n);
+		return gas_mrpc_memcpy_from_gas(dev, dest, src, n);
 	else
 		__memcpy_from_gas(dev, dest, src, n);
+
+	return 0;
 }
 
 /**


### PR DESCRIPTION
Due to security considerations, access to some GAS regions through MRPC command are blocked. This affects 'gas dump' command which reads through the whole region.

Previous `memcpy_from_gas` function raises signal when gas read fails, causing program to exit when some regions are inaccessible. We define new `no_fault` version of the function that returns an error code. CLI checks the error code and print `XX` for those inaccessible memory regions.