### PR TITLE
Fix issues in gas_mrpc_memcpy_from_gas

### DIFF
--- a/lib/gas_mrpc.c
+++ b/lib/gas_mrpc.c
@@ -30,6 +30,8 @@
 #include <signal.h>
 #include <unistd.h>
 
+#define GAS_MRPC_MEMCPY_MAX	512
+
 /**
  * @defgroup GASMRPC Access through MRPC commands
  * @brief Access the GAS through MRPC commands
@@ -100,8 +102,8 @@ int gas_mrpc_memcpy_from_gas(struct switchtec_dev *dev, void *dest,
 
 	while (n) {
 		len = n;
-		if (len > MRPC_MAX_DATA_LEN)
-			len = MRPC_MAX_DATA_LEN;
+		if (len > GAS_MRPC_MEMCPY_MAX)
+			len = GAS_MRPC_MEMCPY_MAX;
 		cmd.len = htole32(len);
 
 		ret = switchtec_cmd(dev, MRPC_GAS_READ, &cmd,

--- a/lib/gas_mrpc.c
+++ b/lib/gas_mrpc.c
@@ -115,6 +115,7 @@ int gas_mrpc_memcpy_from_gas(struct switchtec_dev *dev, void *dest,
 
 		n -= len;
 		dest += len;
+		cmd.gas_offset += len;
 	}
 
 	return 0;


### PR DESCRIPTION
Issues fixed:
- max size defined too large
- source index not updated in loop