### PR TITLE
Add mailbox log parsing support

### DIFF
--- a/cli/argconfig.c
+++ b/cli/argconfig.c
@@ -470,6 +470,23 @@ static int cfg_long_suffix_handler(const char *optarg, void *value_addr,
 	return 0;
 }
 
+static int cfg_long_long_handler(const char *optarg, void *value_addr,
+				 const struct argconfig_options *opt)
+{
+	char *endptr;
+
+	*((unsigned long long *)value_addr) = strtoull(optarg, &endptr, 0);
+	if (errno || optarg == endptr) {
+		fprintf(stderr,
+			"Expected long long integer argument for '--%s/-%c' "
+			"but got '%s'!\n",
+			opt->option, opt->short_option, optarg);
+		return 1;
+	}
+
+	return 0;
+}
+
 static int cfg_double_handler(const char *optarg, void *value_addr,
 			      const struct argconfig_options *opt)
 {
@@ -758,6 +775,7 @@ static type_handler cfg_type_handlers[_CFG_MAX_TYPES] = {
 	[CFG_SIZE_SUFFIX] = cfg_size_suffix_handler,
 	[CFG_LONG] = cfg_long_handler,
 	[CFG_LONG_SUFFIX] = cfg_long_suffix_handler,
+	[CFG_LONG_LONG] = cfg_long_long_handler,
 	[CFG_DOUBLE] = cfg_double_handler,
 	[CFG_BOOL] = cfg_bool_handler,
 	[CFG_BYTE] = cfg_byte_handler,

--- a/cli/argconfig.h
+++ b/cli/argconfig.h
@@ -54,6 +54,7 @@ enum argconfig_types {
 	CFG_SIZE_SUFFIX,
 	CFG_LONG,
 	CFG_LONG_SUFFIX,
+	CFG_LONG_LONG,
 	CFG_DOUBLE,
 	CFG_BOOL,
 	CFG_BYTE,

--- a/cli/fabric.c
+++ b/cli/fabric.c
@@ -1707,8 +1707,8 @@ static int ep_csr_write(int argc, char **argv)
 static int ep_bar_read(int argc, char **argv)
 {
 	unsigned long long val;
-	unsigned long addr;
-	unsigned bytes;
+	unsigned long long addr;
+	unsigned long long bytes;
 	int i;
 	int ret = 0;
 
@@ -1723,7 +1723,7 @@ static int ep_bar_read(int argc, char **argv)
 		struct switchtec_dev *dev;
 		unsigned short pdfid;
 		unsigned short bar;
-		unsigned long addr;
+		unsigned long long addr;
 		unsigned count;
 		unsigned bytes;
 		unsigned print_style;
@@ -1742,7 +1742,7 @@ static int ep_bar_read(int argc, char **argv)
 			required_argument, "pdfid of EP"},
 		{"bar", 'i', "BAR", CFG_SHORT, &cfg.bar,
 			required_argument, "BAR of EP"},
-		{"addr", 'a', "ADDR", CFG_LONG, &cfg.addr,
+		{"addr", 'a', "ADDR", CFG_LONG_LONG, &cfg.addr,
 			required_argument, "address to read"},
 		{"bytes", 'b', "NUM", CFG_POSITIVE, &cfg.bytes,
 			required_argument,
@@ -1824,7 +1824,7 @@ static int ep_bar_write(int argc, char **argv)
 		struct switchtec_dev *dev;
 		unsigned short pdfid;
 		unsigned short bar;
-		unsigned long addr;
+		unsigned long long addr;
 		unsigned bytes;
 		unsigned long value;
 		int assume_yes;
@@ -1840,7 +1840,7 @@ static int ep_bar_write(int argc, char **argv)
 			required_argument, "pdfid of EP"},
 		{"bar", 'i', "BAR", CFG_SHORT, &cfg.bar,
 			required_argument, "BAR of EP"},
-		{"addr", 'a', "ADDR", CFG_LONG, &cfg.addr,
+		{"addr", 'a', "ADDR", CFG_LONG_LONG, &cfg.addr,
 			required_argument, "address to write"},
 		{"bytes", 'b', "NUM", CFG_POSITIVE, &cfg.bytes,
 			required_argument,
@@ -1872,7 +1872,7 @@ static int ep_bar_write(int argc, char **argv)
 	}
 
 	if (!cfg.assume_yes)
-		fprintf(stderr, "Writing 0x%lx to %06lx (%d bytes).\n",
+		fprintf(stderr, "Writing 0x%lx to 0x%llx (%d bytes).\n",
 			cfg.value, cfg.addr, cfg.bytes);
 
 	ret = ask_if_sure(cfg.assume_yes);

--- a/cli/fabric.c
+++ b/cli/fabric.c
@@ -1770,7 +1770,8 @@ static int ep_bar_read(int argc, char **argv)
 		return 1;
 	}
 
-	if ((1 != cfg.bytes) && (2 != cfg.bytes) && (4 != cfg.bytes)) {
+	if ((1 != cfg.bytes) && (2 != cfg.bytes) && (4 != cfg.bytes) &&
+	    (8 != cfg.bytes)) {
 		fprintf(stderr, "Invalid access width\n");
 		return -1;
 	}
@@ -1796,6 +1797,11 @@ static int ep_bar_read(int argc, char **argv)
 			ret = switchtec_ep_bar_read32(cfg.dev, cfg.pdfid,
 						      cfg.bar, addr,
 						      (uint32_t*)&val);
+			break;
+		case 8:
+			ret = switchtec_ep_bar_read64(cfg.dev, cfg.pdfid,
+						      cfg.bar, addr,
+						      (uint64_t*)&val);
 			break;
 		default:
 			fprintf(stderr, "Invalid access width\n");
@@ -1826,7 +1832,7 @@ static int ep_bar_write(int argc, char **argv)
 		unsigned short bar;
 		unsigned long long addr;
 		unsigned bytes;
-		unsigned long value;
+		unsigned long long value;
 		int assume_yes;
 	} cfg = {
 		.pdfid = 0xffff,
@@ -1845,7 +1851,7 @@ static int ep_bar_write(int argc, char **argv)
 		{"bytes", 'b', "NUM", CFG_POSITIVE, &cfg.bytes,
 			required_argument,
 			"number of bytes to write per access (default 4)"},
-		{"value", 'v', "VAL", CFG_LONG, &cfg.value,
+		{"value", 'v', "VAL", CFG_LONG_LONG, &cfg.value,
 			required_argument, "value to write"},
 		{"yes", 'y', "", CFG_NONE, &cfg.assume_yes, no_argument,
 			"assume yes when prompted"},
@@ -1866,13 +1872,14 @@ static int ep_bar_write(int argc, char **argv)
 		return 1;
 	}
 
-	if ((1 != cfg.bytes) && (2 != cfg.bytes) && (4 != cfg.bytes)) {
+	if ((1 != cfg.bytes) && (2 != cfg.bytes) && (4 != cfg.bytes) &&
+	    (8 != cfg.bytes)) {
 		fprintf(stderr, "Invalid access width\n");
 		return -1;
 	}
 
 	if (!cfg.assume_yes)
-		fprintf(stderr, "Writing 0x%lx to 0x%llx (%d bytes).\n",
+		fprintf(stderr, "Writing 0x%llx to 0x%llx (%d bytes).\n",
 			cfg.value, cfg.addr, cfg.bytes);
 
 	ret = ask_if_sure(cfg.assume_yes);
@@ -1890,6 +1897,10 @@ static int ep_bar_write(int argc, char **argv)
 		break;
 	case 4:
 		ret = switchtec_ep_bar_write32(cfg.dev, cfg.pdfid, cfg.bar,
+					       cfg.value, cfg.addr);
+		break;
+	case 8:
+		ret = switchtec_ep_bar_write64(cfg.dev, cfg.pdfid, cfg.bar,
 					       cfg.value, cfg.addr);
 		break;
 	default:

--- a/cli/main.c
+++ b/cli/main.c
@@ -944,13 +944,20 @@ static int log_dump(int argc, char **argv)
 	return ret;
 }
 
-#define CMD_DESC_LOG_PARSE "parse a binary app log to a text file"
+#define CMD_DESC_LOG_PARSE "parse a binary app log or mailbox log to a text file"
 
 static int log_parse(int argc, char **argv)
 {
 	int ret;
 
+	const struct argconfig_choice log_types[] = {
+		{"APP", SWITCHTEC_LOG_PARSE_TYPE_APP, "app log"},
+		{"MAILBOX", SWITCHTEC_LOG_PARSE_TYPE_MAILBOX, "mailbox log"},
+		{}
+	};
+
 	static struct {
+		enum switchtec_log_parse_type log_type;
 		FILE *bin_log_file;
 		const char *bin_log_filename;
 		FILE *log_def_file;
@@ -958,11 +965,18 @@ static int log_parse(int argc, char **argv)
 		FILE *parsed_log_file;
 		const char *parsed_log_filename;
 	} cfg = {
+		.log_type = SWITCHTEC_LOG_PARSE_TYPE_APP,
 		.bin_log_file = NULL,
 		.log_def_file = NULL,
 		.parsed_log_file = NULL,
 	};
 	const struct argconfig_options opts[] = {
+		{"type", 't',
+		 .meta = "TYPE", .cfg_type = CFG_CHOICES,
+		 .value_addr = &cfg.log_type,
+		 .argument_type = required_argument,
+		 .help = "log type to parse (default: APP)",
+		 .choices = log_types},
 		{"log_input", .cfg_type = CFG_FILE_R,
 		 .value_addr = &cfg.bin_log_file,
 		 .argument_type = required_positional,
@@ -974,7 +988,7 @@ static int log_parse(int argc, char **argv)
 		{"parsed_output", .cfg_type = CFG_FILE_W,
 		 .value_addr = &cfg.parsed_log_file,
 		 .argument_type = optional_positional,
-		 .force_default = "app_log.txt",
+		 .force_default = "log.txt",
 		 .help = "parsed output file"},
 		{NULL}};
 
@@ -982,8 +996,7 @@ static int log_parse(int argc, char **argv)
 			&cfg, sizeof(cfg));
 
 	ret = switchtec_parse_log(cfg.bin_log_file, cfg.log_def_file,
-				  cfg.parsed_log_file,
-				  SWITCHTEC_LOG_PARSE_TYPE_APP);
+				  cfg.parsed_log_file, cfg.log_type);
 	if (ret < 0)
 		switchtec_perror("log_parse");
 	else

--- a/cli/main.c
+++ b/cli/main.c
@@ -1393,11 +1393,7 @@ static int fw_info(int argc, char **argv)
 
 	argconfig_parse(argc, argv, CMD_DESC_FW_INFO, opts, &cfg, sizeof(cfg));
 
-	ret = switchtec_get_device_info(cfg.dev, &phase_id, NULL, NULL);
-	if (ret) {
-		switchtec_perror("print fw info");
-		return ret;
-	}
+	phase_id = switchtec_boot_phase(cfg.dev);
 	if (phase_id == SWITCHTEC_BOOT_PHASE_BL1) {
 		fprintf(stderr,
 			"This command is only available in BL2 or Main Firmware!\n");

--- a/cli/main.c
+++ b/cli/main.c
@@ -951,10 +951,6 @@ static int log_parse(int argc, char **argv)
 	int ret;
 
 	static struct {
-		struct switchtec_dev *dev;
-		int out_fd;
-		const char *out_filename;
-		unsigned type;
 		FILE *bin_log_file;
 		const char *bin_log_filename;
 		FILE *log_def_file;

--- a/cli/main.c
+++ b/cli/main.c
@@ -986,7 +986,8 @@ static int log_parse(int argc, char **argv)
 			&cfg, sizeof(cfg));
 
 	ret = switchtec_parse_log(cfg.bin_log_file, cfg.log_def_file,
-				  cfg.parsed_log_file);
+				  cfg.parsed_log_file,
+				  SWITCHTEC_LOG_PARSE_TYPE_APP);
 	if (ret < 0)
 		switchtec_perror("log_parse");
 	else

--- a/inc/switchtec/fabric.h
+++ b/inc/switchtec/fabric.h
@@ -661,6 +661,8 @@ int switchtec_ep_bar_read16(struct switchtec_dev *dev, uint16_t pdfid,
 			    uint8_t bar_index, uint64_t addr, uint16_t *val);
 int switchtec_ep_bar_read32(struct switchtec_dev *dev, uint16_t pdfid,
 			    uint8_t bar_index, uint64_t addr, uint32_t *val);
+int switchtec_ep_bar_read64(struct switchtec_dev *dev, uint16_t pdfid,
+			    uint8_t bar_index, uint64_t addr, uint64_t *val);
 
 int switchtec_ep_bar_write8(struct switchtec_dev *dev, uint16_t pdfid,
 			    uint8_t bar_index, uint8_t val, uint64_t addr);
@@ -668,7 +670,8 @@ int switchtec_ep_bar_write16(struct switchtec_dev *dev, uint16_t pdfid,
 			     uint8_t bar_index, uint16_t val, uint64_t addr);
 int switchtec_ep_bar_write32(struct switchtec_dev *dev, uint16_t pdfid,
 			     uint8_t bar_index, uint32_t val, uint64_t addr);
-
+int switchtec_ep_bar_write64(struct switchtec_dev *dev, uint16_t pdfid,
+			     uint8_t bar_index, uint64_t val, uint64_t addr);
 #ifdef __cplusplus
 }
 #endif

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -195,6 +195,14 @@ enum switchtec_log_type {
 	SWITCHTEC_LOG_NVHDR,
 };
 
+/**
+ * @brief Log types to parse
+ */
+enum switchtec_log_parse_type {
+	SWITCHTEC_LOG_PARSE_TYPE_APP,
+	SWITCHTEC_LOG_PARSE_TYPE_MAILBOX
+};
+
 enum switchtec_fw_type {
 	SWITCHTEC_FW_TYPE_UNKNOWN = 0,
 	SWITCHTEC_FW_TYPE_BOOT,
@@ -361,7 +369,8 @@ int switchtec_log_to_file(struct switchtec_dev *dev,
 			  int fd,
 			  FILE *log_def_file);
 int switchtec_parse_log(FILE *bin_log_file, FILE *log_def_file,
-			FILE *parsed_log_file);
+			FILE *parsed_log_file,
+			enum switchtec_log_parse_type log_type);
 float switchtec_die_temp(struct switchtec_dev *dev);
 
 /**

--- a/lib/fabric.c
+++ b/lib/fabric.c
@@ -1282,6 +1282,17 @@ int switchtec_ep_bar_read32(struct switchtec_dev *dev, uint16_t pdfid,
 	return ret;
 }
 
+int switchtec_ep_bar_read64(struct switchtec_dev *dev, uint16_t pdfid,
+			    uint8_t bar, uint64_t addr, uint64_t *val)
+{
+	int ret;
+
+	ret = ep_bar_read(dev, pdfid, bar, val, addr, 8);
+	*val = le64toh(*val);
+
+	return ret;
+}
+
 static int ep_bar_write(struct switchtec_dev *dev, uint16_t pdfid,
 			uint8_t bar, uint64_t addr,
 			const void *val, size_t n)
@@ -1337,4 +1348,11 @@ int switchtec_ep_bar_write32(struct switchtec_dev *dev, uint16_t pdfid,
 {
 	val = htole32(val);
 	return ep_bar_write(dev, pdfid, bar, addr, &val, 4);
+}
+
+int switchtec_ep_bar_write64(struct switchtec_dev *dev, uint16_t pdfid,
+			     uint8_t bar, uint64_t val, uint64_t addr)
+{
+	val = htole64(val);
+	return ep_bar_write(dev, pdfid, bar, addr, &val, 8);
 }

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -795,7 +795,7 @@ static int switchtec_fw_map_get_active(struct switchtec_dev *dev,
 		return ret;
 
 	info->active = 0;
-	if (map0_update_index < map1_update_index) {
+	if (map0_update_index > map1_update_index) {
 		if (info->part_addr == SWITCHTEC_FLASH_MAP0_PART_START)
 			info->active = 1;
 	} else {

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -1260,6 +1260,10 @@ switchtec_fw_part_summary(struct switchtec_dev *dev)
 
 	for (i = 0; i < nr_info; i++) {
 		type = switchtec_fw_type_ptr(summary, &summary->all[i]);
+		if (type == NULL) {
+			free(summary);
+			return NULL;
+		}
 		if (summary->all[i].active)
 			type->active = &summary->all[i];
 		else

--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -252,7 +252,8 @@ int gasop_flash_part(struct switchtec_dev *dev,
 	uint32_t active_addr = -1;
 	int val;
 
-	memset(info, 0, sizeof(*info));
+	info->running = false;
+	info->active = false;
 
 	switch (part) {
 	case SWITCHTEC_FW_PART_ID_G3_IMG0:

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -774,7 +774,7 @@ static int read_log_defs(FILE *log_def_file, struct log_defs *defs)
 		tok = strtok(NULL, " \t");
 		if (!tok)
 			continue;
-        	mod_id = strtol(tok, NULL, 0);
+		mod_id = strtol(tok, NULL, 0);
 
 		/* reallocate more log definition entries if needed */
 		if (mod_id > defs->num_alloc) {
@@ -789,7 +789,7 @@ static int read_log_defs(FILE *log_def_file, struct log_defs *defs)
 		if (!tok)
 			continue;
 
-        	num_entries = strtol(tok, NULL, 0);
+		num_entries = strtol(tok, NULL, 0);
 
 		/*
 		 * Skip this module if it has already been done. This can happen
@@ -804,7 +804,7 @@ static int read_log_defs(FILE *log_def_file, struct log_defs *defs)
 			continue;
 		}
 
-        	mod_defs->mod_name = strdup(line);
+		mod_defs->mod_name = strdup(line);
 		mod_defs->num_entries = num_entries;
 		mod_defs->entries = calloc(mod_defs->num_entries,
 					   sizeof(*mod_defs->entries));

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -737,12 +737,12 @@ static int realloc_log_defs(struct log_defs *defs, int num_modules)
 }
 
 /**
- * @brief Read a log definition file and store the definitions
+ * @brief Read an app log definition file and store the definitions
  * @param[in] log_def_file - log definition file
  * @param[out] defs 	   - log definitions
  * @return 0 on success, negative value on failure
  */
-static int read_log_defs(FILE *log_def_file, struct log_defs *defs)
+static int read_app_log_defs(FILE *log_def_file, struct log_defs *defs)
 {
 	int ret;
 	char line[512];
@@ -836,17 +836,81 @@ err_free_log_defs:
 }
 
 /**
- * @brief Parse an app log and write the results to a file
+ * @brief Read a mailbox log definition file and store the definitions
+ * @param[in] log_def_file - log definition file
+ * @param[out] defs 	   - log definitions
+ * @return 0 on success, negative value on failure
+ */
+static int read_mailbox_log_defs(FILE *log_def_file, struct log_defs *defs)
+{
+	int ret;
+	char line[512];
+	struct module_log_defs *mod_defs;
+	int num_entries_alloc;
+
+	/*
+	 * The mailbox log definitions don't keep track of modules. Allocate a
+	 * single log definition entry for all definitions.
+	 */
+	ret = realloc_log_defs(defs, 1);
+	if (ret < 0)
+		return ret;
+
+	mod_defs = &defs->module_defs[0];
+	mod_defs->num_entries = 0;
+
+	/* allocate some entries */
+	num_entries_alloc = 100;
+	mod_defs->entries = calloc(num_entries_alloc,
+				   sizeof(*mod_defs->entries));
+	if (!mod_defs->entries)
+		goto err_free_log_defs;
+
+	while (fgets(line, sizeof(line), log_def_file)) {
+		if (mod_defs->num_entries >= num_entries_alloc) {
+			/* allocate more entries */
+			num_entries_alloc *= 2;
+			mod_defs->entries = realloc(mod_defs->entries,
+						    (num_entries_alloc *
+						     sizeof(*mod_defs->entries)));
+			if (!mod_defs->entries)
+				goto err_free_log_defs;			
+		}
+
+		mod_defs->entries[mod_defs->num_entries] = strdup(line);
+		if (!mod_defs->entries[mod_defs->num_entries])
+			goto err_free_log_defs;
+
+		mod_defs->num_entries++;
+	}
+
+	if (ferror(log_def_file)) {
+		errno = SWITCHTEC_ERR_LOG_DEF_READ_ERROR;
+		goto err_free_log_defs;
+	}
+
+	return 0;
+
+err_free_log_defs:
+	free_log_defs(defs);
+	return -1;
+}
+
+/**
+ * @brief Parse an app log or mailbox log and write the results to a file
  * @param[in] log_data	     - logging data
  * @param[in] count	     - number of entries
  * @param[in] init_entry_idx - index of the initial entry
  * @param[in] defs           - log definitions
+ * @param[in] log_type       - log type
  * @param[in] log_file	     - log output file
  * @return 0 on success, negative value on failure
  */
 static int write_parsed_log(struct log_a_data log_data[],
 			    size_t count, int init_entry_idx,
-			    struct log_defs *defs, FILE *log_file)
+			    struct log_defs *defs,
+			    enum switchtec_log_parse_type log_type,
+			    FILE *log_file)
 {
 	int i;
 	int entry_idx = init_entry_idx;
@@ -857,11 +921,17 @@ static int write_parsed_log(struct log_a_data log_data[],
 	unsigned int log_sev;
 	const char *log_sev_strs[] = {"DISABLED", "HIGHEST", "HIGH", "MEDIUM",
 				      "LOW", "LOWEST"};
+	bool is_bl1;
 	struct module_log_defs *mod_defs;
 
-	if (entry_idx == 0)
-		fputs("   #|Timestamp                |Module       |Severity |Event\n",
-		      log_file);
+	if (entry_idx == 0) {
+		if (log_type == SWITCHTEC_LOG_PARSE_TYPE_APP)
+			fputs("   #|Timestamp                |Module       |Severity |Event\n",
+		      	      log_file);
+		else
+			fputs("   #|Timestamp                |Source |Event\n",
+		      	      log_file);
+	}
 
 	for (i = 0; i < count; i ++) {
 		/* timestamp is in the first 2 DWords */
@@ -880,26 +950,45 @@ static int write_parsed_log(struct log_a_data log_data[],
 		hours = time % 24;
 		days = time / 24;
 
-		/*
-		 * log entry number, module ID, and log severity are in the
-		 * 3rd DWord
-		 */
-		entry_num = log_data[i].data[2] & 0x0000FFFF;
-		mod_id = (log_data[i].data[2] >> 16) & 0xFFF;
-		log_sev = (log_data[i].data[2] >> 28) & 0xF;
+		if (log_type == SWITCHTEC_LOG_PARSE_TYPE_APP) {
+			/*
+			 * app log: module ID and log severity are in the 3rd
+			 * DWord
+			 */
+			mod_id = (log_data[i].data[2] >> 16) & 0xFFF;
+			log_sev = (log_data[i].data[2] >> 28) & 0xF;		
 
-		/* validate the module ID */
-		if ((mod_id > defs->num_alloc) ||
-		    (strlen(defs->module_defs[mod_id].mod_name) == 0)) {
-			if (fprintf(log_file, "(Invalid module ID: 0x%x)\n",
-				    mod_id) < 0)
-				goto ret_print_error;
-			continue;
+			if ((mod_id > defs->num_alloc) ||
+			    (defs->module_defs[mod_id].mod_name == NULL) ||
+			    (strlen(defs->module_defs[mod_id].mod_name) == 0)) {
+				if (fprintf(log_file, "(Invalid module ID: 0x%x)\n",
+					mod_id) < 0)
+					goto ret_print_error;
+				continue;
+			}
+
+			if (log_sev >= ARRAY_SIZE(log_sev_strs)) {
+				if (fprintf(log_file, "(Invalid log severity: %d)\n",
+					log_sev) < 0)
+					goto ret_print_error;
+				continue;
+			}
+		} else {
+			/*
+			 * mailbox log: BL1/BL2 indication is in the 3rd
+			 * DWord
+			 */
+			is_bl1 = (((log_data[i].data[2] >> 27) & 1) == 0);
+
+			/* mailbox log definitions are all in the first entry */
+			mod_id = 0;
 		}
 
 		mod_defs = &defs->module_defs[mod_id];
 
-		/* validate the entry number */
+		/* entry number is in the 3rd DWord */
+		entry_num = log_data[i].data[2] & 0x0000FFFF;
+
 		if (entry_num >= mod_defs->num_entries) {
 			if (fprintf(log_file,
 				    "(Invalid log entry number: %d (module 0x%x))\n",
@@ -908,21 +997,26 @@ static int write_parsed_log(struct log_a_data log_data[],
 			continue;
 		}
 
-		/* validate the log severity  */
-		if (log_sev >= ARRAY_SIZE(log_sev_strs)) {
-			if (fprintf(log_file, "(Invalid log severity: %d)\n",
-				    log_sev) < 0)
-				goto ret_print_error;
-			continue;
-		}
-
+		/* print the entry index and timestamp */
 		if (fprintf(log_file,
-			    "%04d|%03dd %02d:%02d:%02d.%03d,%03d,%03d|%-12s |%-8s |",
+			    "%04d|%03dd %02d:%02d:%02d.%03d,%03d,%03d|",
 			    entry_idx, days, hours, mins, secs, millis,
-			    micros, nanos, mod_defs->mod_name,
-			    log_sev_strs[log_sev]) < 0)
+			    micros, nanos) < 0)
 			goto ret_print_error;
 
+		if (log_type == SWITCHTEC_LOG_PARSE_TYPE_APP) {
+			/* print the module name and log severity */
+			if (fprintf(log_file, "%-12s |%-8s |",
+			    mod_defs->mod_name, log_sev_strs[log_sev]) < 0)
+				goto ret_print_error;
+		} else {
+			/* print the log source (BL1/BL2) */
+			if (fprintf(log_file, "%-6s |",
+			    (is_bl1 ? "BL1" : "BL2")) < 0)
+				goto ret_print_error;
+		}
+
+		/* print the log entry */
 	  	if (fprintf(log_file, mod_defs->entries[entry_num],
 	  		    log_data[i].data[3], log_data[i].data[4],
 			    log_data[i].data[5], log_data[i].data[6],
@@ -960,7 +1054,7 @@ static int log_a_to_file(struct switchtec_dev *dev, int sub_cmd_id,
 
 	if (log_def_file != NULL) {
 		/* read the log definition file into defs */
-		ret = read_log_defs(log_def_file, &defs);
+		ret = read_app_log_defs(log_def_file, &defs);
 		if (ret < 0)
 			return ret;
 	}
@@ -986,7 +1080,9 @@ static int log_a_to_file(struct switchtec_dev *dev, int sub_cmd_id,
 
 			/* parse the log data and write it to a file */
 			ret = write_parsed_log(res.data, res.hdr.count,
-					       entry_idx, &defs, log_file);
+					       entry_idx, &defs,
+					       SWITCHTEC_LOG_PARSE_TYPE_APP,
+					       log_file);
 			if (ret < 0)
 				goto ret_free_log_defs;
 
@@ -1103,14 +1199,16 @@ int switchtec_log_to_file(struct switchtec_dev *dev,
 }
 
 /**
- * @brief Parse a binary app log to a text file
- * @param[in]  bin_log_file    - Binary app log input file
- * @param[in]  log_def_file    - Log definition file
- * @param[in]  parsed_log_file - Parsed output file
+ * @brief Parse a binary app log or mailbox log to a text file
+ * @param[in] bin_log_file    - Binary log input file
+ * @param[in] log_def_file    - Log definition file
+ * @param[in] parsed_log_file - Parsed output file
+ * @param[in] log_type        - log type
  * @return 0 on success, error code on failure
  */
 int switchtec_parse_log(FILE *bin_log_file, FILE *log_def_file,
-			FILE *parsed_log_file)
+			FILE *parsed_log_file,
+			enum switchtec_log_parse_type log_type)
 {
 	int ret;
 	struct log_a_data log_data;
@@ -1119,16 +1217,26 @@ int switchtec_parse_log(FILE *bin_log_file, FILE *log_def_file,
 		.num_alloc = 0};
 	int entry_idx = 0;
 
+	if ((log_type != SWITCHTEC_LOG_PARSE_TYPE_APP) &&
+	    (log_type != SWITCHTEC_LOG_PARSE_TYPE_MAILBOX)) {
+		errno = EINVAL;
+		return -errno;
+	}
+
 	/* read the log definition file into defs */
-	ret = read_log_defs(log_def_file, &defs);
+	if (log_type == SWITCHTEC_LOG_PARSE_TYPE_APP)
+		ret = read_app_log_defs(log_def_file, &defs);
+	else
+		ret = read_mailbox_log_defs(log_def_file, &defs);
+
 	if (ret < 0)
 		return ret;
 
-	/* parse each app log entry */
+	/* parse each log entry */
 	while (fread(&log_data, sizeof(struct log_a_data), 1,
 		     bin_log_file) == 1) {
 		ret = write_parsed_log(&log_data, 1, entry_idx, &defs,
-				       parsed_log_file);
+				       log_type, parsed_log_file);
 		if (ret < 0)
 			goto ret_free_log_defs;
 


### PR DESCRIPTION
Add mailbox log parsing support to the Switchtec library file. Mailbox logs are different from app logs as follows:
-the log definition file doesn't divide the definitions into modules. All definitions are in a single list.
-log severities are always the same
-bit 27 of the 3rd DWord of a log entry indicates the log source (BL1/BL2)

The "log-parse" command now takes a parameter to specify the log type (APP or MAILBOX) so that mailbox logs can be parsed.
