### PR TITLE
Fix switchtec_open device name parsing issues

### DIFF
--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -212,11 +212,6 @@ struct switchtec_dev *switchtec_open(const char *device)
 	char *endptr;
 	struct switchtec_dev *ret;
 
-	if (sscanf(device, "%2049[^:]:%i", path, &inst) == 2) {
-		ret = switchtec_open_eth(path, inst);
-		goto found;
-	}
-
 	if (sscanf(device, "%2049[^@]@%i", path, &dev) == 2) {
 		ret = switchtec_open_i2c(path, dev);
 		goto found;
@@ -245,6 +240,11 @@ struct switchtec_dev *switchtec_open(const char *device)
 
 	if (sscanf(device, "%i@%i", &bus, &dev) == 2) {
 		ret = switchtec_open_i2c_by_adapter(bus, dev);
+		goto found;
+	}
+
+	if (sscanf(device, "%2049[^:]:%i", path, &inst) == 2) {
+		ret = switchtec_open_eth(path, inst);
 		goto found;
 	}
 

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -212,6 +212,11 @@ struct switchtec_dev *switchtec_open(const char *device)
 	char *endptr;
 	struct switchtec_dev *ret;
 
+	if (sscanf(device, "%i@%i", &bus, &dev) == 2) {
+		ret = switchtec_open_i2c_by_adapter(bus, dev);
+		goto found;
+	}
+
 	if (sscanf(device, "%2049[^@]@%i", path, &dev) == 2) {
 		ret = switchtec_open_i2c(path, dev);
 		goto found;
@@ -235,11 +240,6 @@ struct switchtec_dev *switchtec_open(const char *device)
 
 	if (sscanf(device, "%x:%x:%x.%x", &domain, &bus, &dev, &func) == 4) {
 		ret = switchtec_open_by_pci_addr(domain, bus, dev, func);
-		goto found;
-	}
-
-	if (sscanf(device, "%i@%i", &bus, &dev) == 2) {
-		ret = switchtec_open_i2c_by_adapter(bus, dev);
 		goto found;
 	}
 


### PR DESCRIPTION
Change parsing pattern order to fix PCIe and I2C address parsing issues.

All cases have been verified to work now.

------------------------

I have moved the Ethernet address parsing to the end. Also found I2C parsing didn't work, fixed here as well. I think it's OK to combine the 2 fixes in on PR since they all fix the same 'device name parsing' issue. Let me know if otherwise. 

The team has decided not to adopt the more formal `switchtec://hostname:port` proposal, due to compatibility considerations. 