### PR TITLE
Pull Request to Integrate LTSSM Log MRPC into switchtec_user callable functions

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -334,17 +334,17 @@ char * link_rate_conversion(uint8_t link_rate);
 
 char* major_state_string[11] =
 {
-        "Detect ",
-        "Poll   ",
-        "Cfg    ",
-        "L0     ",
-        "Recov  ",
+        "Detect",
+        "Poll",
+        "Cfg",
+        "L0",
+        "Recov",
         "Disable",
-        "Loopbk ",
-        "HotRst ",
-        "TxL0s  ",
-        "L1     ",
-        "L2     "
+        "Loopbk",
+        "HotRst",
+        "TxL0s",
+        "L1",
+        "L2"
 };
 
 char* minor_state_string[11][12] =
@@ -387,8 +387,8 @@ char* minor_state_string[11][12] =
         "IDLE"
     },
     {
-        "INACTIVE   ",
-        "L0         ",
+        "INACTIVE",
+        "L0",
         "TX_EL_IDLE ",
         "TX_IDLE_MIN",
     },
@@ -432,10 +432,10 @@ char* minor_state_string[11][12] =
     },
     {
         "INACTIVE",
-        "IDLE    ",
-        "TO_L0   ",
-        "FTS0    ",
-        "FTS1    ",
+        "IDLE",
+        "TO_L0",
+        "FTS0",
+        "FTS1",
     },
     {
         "INACTIVE",
@@ -454,8 +454,6 @@ char* minor_state_string[11][12] =
 };
 
 char * link_rate_conversion(uint8_t link_rate) {
-
-
     switch(link_rate) {
          case 0:
               return "2.5G";
@@ -464,11 +462,10 @@ char * link_rate_conversion(uint8_t link_rate) {
          case 2:
               return "8.0G";
          case 3:
-              return "16G";
+              return "16.0G";
          default:
               return "2.5G";
     }
-
     return "2.5G";
 }
 
@@ -501,12 +498,12 @@ static int ltssm_log(int argc, char **argv) {
 	port = cfg.phy_port;
 	ret = switchtec_ltssm_log(cfg.dev, port, &log_count, ltssm_log_output_data);
 	printf("LTSSM Log for Physical Port %d (autowrap ON)\n\n",port);
-	printf("Idx\tDeltaTime\tRate\tMajor_State\tMinor_State\n");
+	printf("Idx\tDeltaTime\tPCIeRate\tMajor_State\tMinor_State\n");
 	for(i = 0; i < log_count ; i++) {
 		if(ltssm_log_output_data[i].major_state < 15) {
 			printf("%3d\t", i);
 			printf("%09x\t", ltssm_log_output_data[i].tstamp);
-			printf("%4s\t", link_rate_conversion(ltssm_log_output_data[i].link_rate));
+			printf("%8s\t", link_rate_conversion(ltssm_log_output_data[i].link_rate));
 			printf("%11s\t", major_state_string[ltssm_log_output_data[i].major_state]);
 			printf(".%-11s ", minor_state_string[ltssm_log_output_data[i].major_state][ltssm_log_output_data[i].minor_state]);
 			printf("\n");

--- a/cli/main.c
+++ b/cli/main.c
@@ -97,7 +97,7 @@ int switchtec_handler(const char *optarg, void *value_addr,
  * build is non-trivial. After evaluating the development effort
  * and the resources available, we have decided to remove Windows
  * build support from release roadmap.
- * 
+ *
  */
 int mfg_handler(const char *optarg, void *value_addr,
 		const struct argconfig_options *opt)
@@ -546,6 +546,38 @@ static int bw(int argc, char **argv)
 	free(port_ids);
 	return 0;
 }
+
+#define CMD_DESC_LTMON "dump port ltssm state machine"
+static int ltmon(int argc, char **argv)
+{
+	int ret;
+	static struct {
+		struct switchtec_dev *dev;
+		int phy_port;
+	} cfg = {
+		.phy_port = 0xff
+	};
+	const struct argconfig_options opts[] = {
+		DEVICE_OPTION,
+		{"physical", 'f', "", CFG_NONNEGATIVE, &cfg.phy_port, required_argument,
+			"physical port ID"},
+		{NULL}};
+
+	argconfig_parse(argc, argv, CMD_DESC_LTMON, opts, &cfg, sizeof(cfg));
+
+	if (cfg.phy_port == 0xff)
+		printf("physical port: all\n");
+
+	ret = switchtec_get_port_ltmon_dmp(cfg.dev, cfg.phy_port);
+
+	if (ret != 0) {
+		switchtec_perror("ltmon_dmp");
+		return 1;
+	}
+
+	return 0;
+}
+
 
 #define CMD_DESC_LATENCY "measure the latency of a port"
 
@@ -2221,12 +2253,14 @@ static const struct cmd commands[] = {
 	CMD(info, CMD_DESC_INFO),
 	CMD(gui, CMD_DESC_GUI),
 	CMD(status, CMD_DESC_STATUS),
+	CMD(ltmon, CMD_DESC_LTMON),
 	CMD(bw, CMD_DESC_BW),
 	CMD(latency, CMD_DESC_LATENCY),
 	CMD(events, CMD_DESC_EVENTS),
 	CMD(event_wait, CMD_DESC_EVENT_WAIT),
 	CMD(log_dump, CMD_DESC_LOG_DUMP),
 	CMD(log_parse, CMD_DESC_LOG_PARSE),
+	CMD(ltssm_log, CMD_DESC_LTSSM_LOG),
 	CMD(test, CMD_DESC_TEST),
 	CMD(temp, CMD_DESC_TEMP),
 	CMD(port_bind_info, CMD_DESC_PORT_BIND_INFO),

--- a/cli/main.c
+++ b/cli/main.c
@@ -469,7 +469,7 @@ char * link_rate_conversion(uint8_t link_rate) {
     return "2.5G";
 }
 
-#define CMD_DESC_LTSSM_LOG "Display LTMON log"
+#define CMD_DESC_LTSSM_LOG "Display LTSSM log"
 static int ltssm_log(int argc, char **argv) {
 	int ret;
 	int port;

--- a/cli/main.c
+++ b/cli/main.c
@@ -731,38 +731,6 @@ static int bw(int argc, char **argv)
 	return 0;
 }
 
-#define CMD_DESC_LTMON "dump port ltssm state machine"
-static int ltmon(int argc, char **argv)
-{
-	int ret;
-	static struct {
-		struct switchtec_dev *dev;
-		int phy_port;
-	} cfg = {
-		.phy_port = 0xff
-	};
-	const struct argconfig_options opts[] = {
-		DEVICE_OPTION,
-		{"physical", 'f', "", CFG_NONNEGATIVE, &cfg.phy_port, required_argument,
-			"physical port ID"},
-		{NULL}};
-
-	argconfig_parse(argc, argv, CMD_DESC_LTMON, opts, &cfg, sizeof(cfg));
-
-	if (cfg.phy_port == 0xff)
-		printf("physical port: all\n");
-
-	ret = switchtec_get_port_ltmon_dmp(cfg.dev, cfg.phy_port);
-
-	if (ret != 0) {
-		switchtec_perror("ltmon_dmp");
-		return 1;
-	}
-
-	return 0;
-}
-
-
 #define CMD_DESC_LATENCY "measure the latency of a port"
 
 static int latency(int argc, char **argv)
@@ -2437,7 +2405,6 @@ static const struct cmd commands[] = {
 	CMD(info, CMD_DESC_INFO),
 	CMD(gui, CMD_DESC_GUI),
 	CMD(status, CMD_DESC_STATUS),
-	CMD(ltmon, CMD_DESC_LTMON),
 	CMD(bw, CMD_DESC_BW),
 	CMD(latency, CMD_DESC_LATENCY),
 	CMD(events, CMD_DESC_EVENTS),

--- a/cli/main.c
+++ b/cli/main.c
@@ -330,9 +330,9 @@ static char *pci_acs_to_string(char *buf, size_t buflen, int acs_ctrl,
 	return buf;
 }
 
-char * link_rate_conversion(uint8_t link_rate);
+// char * link_rate_conversion(uint8_t link_rate);
 
-char* major_state_string[11] =
+static const char* major_state_string[11] =
 {
         "Detect",
         "Poll",
@@ -347,7 +347,7 @@ char* major_state_string[11] =
         "L2"
 };
 
-char* minor_state_string[11][12] =
+static const char* minor_state_string[11][12] =
 {
     {
         "INACTIVE",
@@ -453,7 +453,7 @@ char* minor_state_string[11][12] =
     }
 };
 
-char * link_rate_conversion(uint8_t link_rate) {
+static char * link_rate_conversion(uint8_t link_rate) {
     switch(link_rate) {
          case 0:
               return "2.5G";
@@ -494,6 +494,11 @@ static int ltssm_log(int argc, char **argv) {
 		{NULL}};
 
 	argconfig_parse(argc, argv, CMD_DESC_LTSSM_LOG, opts, &cfg, sizeof(cfg));
+
+	if (switchtec_is_gen3(cfg.dev)) {
+		fprintf (stderr, "This command is not supported on Switchtec Gen3\n");
+		return 0;
+	}
 
 	port = cfg.phy_port;
 	ret = switchtec_ltssm_log(cfg.dev, port, &log_count, ltssm_log_output_data);

--- a/cli/main.c
+++ b/cli/main.c
@@ -476,11 +476,13 @@ char * link_rate_conversion(uint8_t link_rate) {
 static int ltssm_log(int argc, char **argv) {
 	int ret;
 	int port;
-        int log_count, i = 0;
+	int log_count, i = 0;
 
 	static struct {
 		struct switchtec_dev *dev;
 		int phy_port;
+		int dump;
+		int nowrap;
 	} cfg = {
 		.phy_port = 0xff
 	};
@@ -490,7 +492,7 @@ static int ltssm_log(int argc, char **argv) {
 
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
-		{"port", 'p', "", CFG_NONNEGATIVE, &cfg.phy_port, required_argument,
+		{"physical", 'f', "", CFG_NONNEGATIVE, &cfg.phy_port, required_argument,
 			"physical port ID"},
 		{NULL}};
 
@@ -498,16 +500,16 @@ static int ltssm_log(int argc, char **argv) {
 
 	port = cfg.phy_port;
 	ret = switchtec_ltssm_log(cfg.dev, port, &log_count, ltssm_log_output_data);
-
-	printf("Log Index  -  Timestamp  - Link Rate -  Major State  - Minor State \n");
+	printf("LTSSM Log for Physical Port %d (autowrap ON)\n\n",port);
+	printf("Idx\tDeltaTime\tRate\tMajor_State\tMinor_State\n");
 	for(i = 0; i < log_count ; i++) {
 		if(ltssm_log_output_data[i].major_state < 15) {
-		printf("%10d ", i);
-		printf("%12x ", ltssm_log_output_data[i].tstamp);
-		printf("%10s ", link_rate_conversion(ltssm_log_output_data[i].link_rate));
-		printf("%12s . ", major_state_string[ltssm_log_output_data[i].major_state]);
-		printf("     %-12s ", minor_state_string[ltssm_log_output_data[i].major_state][ltssm_log_output_data[i].minor_state]);
-		printf("\n");
+			printf("%3d\t", i);
+			printf("%09x\t", ltssm_log_output_data[i].tstamp);
+			printf("%4s\t", link_rate_conversion(ltssm_log_output_data[i].link_rate));
+			printf("%11s\t", major_state_string[ltssm_log_output_data[i].major_state]);
+			printf(".%-11s ", minor_state_string[ltssm_log_output_data[i].major_state][ltssm_log_output_data[i].minor_state]);
+			printf("\n");
 		}
 	}
 

--- a/examples/temp_linux.py
+++ b/examples/temp_linux.py
@@ -83,7 +83,8 @@ def echo_cmd(dev):
                            format(sub_cmd_in, sub_cmd_out))
 
 def die_temp(dev):
-    dev.cmd(MRPC_DIETEMP, struct.pack("<L", MRPC_DIETEMP_SET_MEAS))
+    # Comment out this next line for Gen4 switch
+    # dev.cmd(MRPC_DIETEMP, struct.pack("<L", MRPC_DIETEMP_SET_MEAS))
     temp_packed = dev.cmd(MRPC_DIETEMP, struct.pack("<L", MRPC_DIETEMP_GET), 4)
 
     temp, = struct.unpack("<L", temp_packed)

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -306,8 +306,6 @@ enum switchtec_event_id {
 	SWITCHTEC_MAX_EVENTS,
 };
 
-
-
 /*********** Platform Functions ***********/
 
 struct switchtec_dev *switchtec_open(const char *device);
@@ -372,7 +370,7 @@ typedef struct {
 
 int switchtec_ltssm_log(struct switchtec_dev *dev, int port, int *log_count, ltssm_log_data *log_data);
 int switchtec_status(struct switchtec_dev *dev,
-		struct switchtec_status **status);
+			      struct switchtec_status **status);
 void switchtec_status_free(struct switchtec_status *status, int ports);
 int switchtec_get_device_info(struct switchtec_dev *dev,
 			      enum switchtec_boot_phase *phase,

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -306,6 +306,8 @@ enum switchtec_event_id {
 	SWITCHTEC_MAX_EVENTS,
 };
 
+
+
 /*********** Platform Functions ***********/
 
 struct switchtec_dev *switchtec_open(const char *device);
@@ -356,15 +358,16 @@ int switchtec_set_pax_id(struct switchtec_dev *dev, int pax_id);
 int switchtec_echo(struct switchtec_dev *dev, uint32_t input, uint32_t *output);
 int switchtec_hard_reset(struct switchtec_dev *dev);
 
+/* Data structure for LTSSM log */
 typedef struct {
-     uint8_t  : 3;
-     uint8_t minor_state : 4;
-     uint8_t major_state : 4;
-     uint8_t  : 2;
-     uint8_t link_rate: 2;
+     uint32_t  : 3;
+     uint32_t minor_state : 4;
+     uint32_t major_state : 4;
+     uint32_t  : 2;
+     uint32_t link_rate: 2;
      uint32_t : 17;
      uint32_t tstamp: 26;
-     uint8_t : 6;
+     uint32_t : 6;
 }__attribute__((packed)) ltssm_log_data;
 
 int switchtec_ltssm_log(struct switchtec_dev *dev, int port, int *log_count, ltssm_log_data *log_data);

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -355,8 +355,21 @@ switchtec_boot_phase(struct switchtec_dev *dev);
 int switchtec_set_pax_id(struct switchtec_dev *dev, int pax_id);
 int switchtec_echo(struct switchtec_dev *dev, uint32_t input, uint32_t *output);
 int switchtec_hard_reset(struct switchtec_dev *dev);
+
+typedef struct {
+     uint8_t  : 3;
+     uint8_t minor_state : 4;
+     uint8_t major_state : 4;
+     uint8_t  : 2;
+     uint8_t link_rate: 2;
+     uint32_t : 17;
+     uint32_t tstamp: 26;
+     uint8_t : 6;
+}__attribute__((packed)) ltssm_log_data;
+
+int switchtec_ltssm_log(struct switchtec_dev *dev, int port, int *log_count, ltssm_log_data *log_data);
 int switchtec_status(struct switchtec_dev *dev,
-		     struct switchtec_status **status);
+		struct switchtec_status **status);
 void switchtec_status_free(struct switchtec_status *status, int ports);
 int switchtec_get_device_info(struct switchtec_dev *dev,
 			      enum switchtec_boot_phase *phase,


### PR DESCRIPTION
This request covers the following changes:
- New code in main.c and switchtec.c to use the MRPC command LTSSM Monitor Command (LTMON) to dump link training information to a log (STDOUT)
- New structs defined in switchtec.h to support the output format
- Minor edit to temp_linux.py in the examples folder which recommends commenting out SET_MEAS as it is not required in the Gen4 switch but it is required in the Gen3 switch

Credits
- The original LTSSM Monitor code was written by Rakesh Vitta and checked into my repo (yungwesl) for convenience.  Although I maintain this code, the work was done entirely by Rakesh (so thank him and also blame him :))

Suggested Enhancements
- This code implements only the read function of the MRPC LTSSM Monitor Command
- There are some configurable items which can be used to enhance the behavior
-- Adding the ability to set the LTSSM mode to "nowrap" (however, this requires a link retrain following the config)

 