### PR TITLE
Fix linux PCIe Bus-Dev-Func display issue

### DIFF
--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -586,7 +586,7 @@ static int linux_get_devices(struct switchtec_dev *dev,
 			continue;
 
 		if (status[i].port.upstream) {
-			status->pci_bdf = strdup(basename(searchpath));
+			status[i].pci_bdf = strdup(basename(searchpath));
 			get_port_bdf_path(&status[i]);
 			continue;
 		}


### PR DESCRIPTION
Fixed missing index to the `status` pointer.