### PR TITLE
Add new command fw_meta_info for getting metadata info from Flash partition

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1491,7 +1491,7 @@ static int fw_meta_info(int argc, char **argv)
 
 	if (inf.valid) {
 		printf("Image Version: %s \n", inf.version);
-		printf("Image Length: 0x%lx \n", inf.image_len);
+		printf("Image Length: 0x%x \n", (int)inf.image_len);
 		printf("Image CRC: 0x%lx \n", inf.image_crc);
 		printf("Secure Version: 0x%lx \n", inf.secure_version);
 		printf("Public Key Exponent : 0x");

--- a/cli/main.c
+++ b/cli/main.c
@@ -1434,24 +1434,25 @@ static int fw_info(int argc, char **argv)
 	return 0;
 }
 
-static char * part_to_string(int partition_id) {
-       switch(partition_id){
+static char *part_to_string(int partition_id)
+{
+	switch (partition_id) {
 
-               case 0: return "Partition Map 0";
-               case 1: return "Partition Map 1";
-               case 2: return "Key Manifest 0";
-               case 3: return "Key Manifest 1";
-               case 4: return "BL2 0";
-               case 5: return "BL2 1";
-               case 6: return "Cfg 0";
-               case 7: return "Cfg 1";
-               case 8: return "Main Fw 0";
-               case 9: return "Main FW 1";
-               default: return "Invalid Partition ID";
-       }
+	case 0: return "Partition Map 0";
+	case 1: return "Partition Map 1";
+	case 2: return "Key Manifest 0";
+	case 3: return "Key Manifest 1";
+	case 4: return "BL2 0";
+	case 5: return "BL2 1";
+	case 6: return "Cfg 0";
+	case 7: return "Cfg 1";
+	case 8: return "Main Fw 0";
+	case 9: return "Main FW 1";
+	default: return "Invalid Partition ID";
+	}
 }
 
-#define CMD_DESC_FW_META_INFO "return metadata information from the selected flash partition"
+#define CMD_DESC_FW_META_INFO "Return metadata information from the selected flash partition"
 
 static int fw_meta_info(int argc, char **argv)
 {

--- a/cli/main.c
+++ b/cli/main.c
@@ -1456,65 +1456,60 @@ static char *part_to_string(int partition_id)
 
 static int fw_meta_info(int argc, char **argv)
 {
-       int ret, i, nr_info;
-       static struct {
-               struct switchtec_dev *dev;
-               int partition_id;
-       } cfg = {};
+	int ret, i, nr_info;
+	static struct {
+		struct switchtec_dev *dev;
+		int partition_id;
+	} cfg = {};
 
-       struct switchtec_fw_image_info inf;
-       struct switchtec_fw_metadata_gen4 *metadata;
+	struct switchtec_fw_image_info inf;
 
-       const struct argconfig_options opts[] = {
-               DEVICE_OPTION,
-               {"flash_part", 'p', "", CFG_NONNEGATIVE, &cfg.partition_id, required_argument,
-                       "Flash Partition ID"},
-               {NULL}};
+	const struct argconfig_options opts[] = {
+		DEVICE_OPTION,
+		{"flash_part", 'p', "", CFG_NONNEGATIVE, &cfg.partition_id,
+			required_argument, "Flash Partition ID"},
+		{NULL} };
 
-       argconfig_parse(argc, argv, CMD_DESC_FW_META_INFO, opts, &cfg, sizeof(cfg));
+	argconfig_parse(argc, argv, CMD_DESC_FW_META_INFO, opts, &cfg,
+			sizeof(cfg));
 
-       if(cfg.partition_id > 9 ) {
-               printf("Invalid Partition ID \n");
-               return -1;
-       }
+	if (cfg.partition_id > 9) {
+		printf("Invalid Partition ID \n");
+		return -1;
+	}
+	inf.part_id = cfg.partition_id;
+	nr_info = 1;
 
-       inf.part_id = cfg.partition_id;
-       nr_info = 1;
+	if (!switchtec_is_gen4(cfg.dev)) {
+		printf("This command is only supported on Gen.4 Switches \n");
+		return -1;
+	}
+	ret = switchtec_fw_part_info(cfg.dev, nr_info, &inf);
 
-       if( !switchtec_is_gen4(cfg.dev) ){
-               printf("This command is only supported on Gen.4 Switches \n");
-               return -1;
-       }
-       ret = switchtec_fw_part_info(cfg.dev, nr_info, &inf);
+	printf("Switchtec Flash Partition Info \n");
+	printf("Partition Type: %s \n", part_to_string(inf.part_id));
 
-       metadata = (struct switchtec_fw_metadata_gen4 *)malloc(sizeof(metadata));
-       metadata = (struct switchtec_fw_metadata_gen4 *)inf.metadata;
+	if (inf.valid) {
+		printf("Image Version: %s \n", inf.version);
+		printf("Image Length: 0x%lx \n", inf.image_len);
+		printf("Image CRC: 0x%lx \n", inf.image_crc);
+		printf("Secure Version: 0x%lx \n", inf.secure_version);
+		printf("Public Key Exponent : 0x");
+		for (i = 0; i <= 3; i++)
+			printf("%02x", inf.public_key_exponent[i]);
+		printf("\n");
+		printf("Public Key Modulus : \n");
+		for (i = 0; i < 512; i++) {
+			if ((i%15 == 0) && (i != 0))
+				printf("\n");
+			printf("%02x:", inf.public_key_modulus[i]);
+		}
+		printf("\n");
+	} else {
+		printf("Partition Invalid \n");
+	}
 
-       printf("Switchtec Flash Partition Info \n");
-       printf("Partition Type: %s \n", part_to_string(inf.part_id));
-
-       if(inf.valid) {
-               printf("Image Version: %s \n", inf.version);
-               printf("Image Length: 0x%x \n", metadata->image_len);
-               printf("Image CRC: 0x%x \n", metadata->image_crc);
-               printf("Secure Version: 0x%x \n", metadata->secure_version);
-               printf("Public Key Exponent : 0x");
-               for(i=0; i<=3; i++) {
-                       printf("%02x", metadata->public_key_exponent[i]);
-               }
-               printf("\n");
-               printf("Public Key Modulus : \n");
-               for(i=0; i< 512; i++) {
-                       if((i%15 == 0) && (i !=0))
-                                printf("\n");
-                        printf("%02x:", metadata->public_key_modulus[i]);
-               }
-               printf("\n");
-       } else {
-               printf("Partition Invalid \n");
-       }
-
-       return ret;
+	return ret;
 }
 
 #define CMD_DESC_FW_UPDATE "upload a new firmware image to flash"

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -241,6 +241,38 @@ struct switchtec_fw_image_info {
 	unsigned long secure_version;
 };
 
+struct switchtec_fw_metadata_gen4 {
+        char magic[4];
+        char sub_magic[4];
+        uint32_t hdr_version;
+        uint32_t secure_version;
+        uint32_t header_len;
+        uint32_t metadata_len;
+        uint32_t image_len;
+        uint32_t type;
+        uint32_t rsvd;
+        uint32_t version;
+        uint32_t sequence;
+        uint32_t reserved1;
+        uint8_t date_str[8];
+        uint8_t time_str[8];
+        uint8_t img_str[16];
+        uint8_t rsvd1[4];
+        uint32_t image_crc;
+        uint8_t public_key_modulus[512];
+        uint8_t public_key_exponent[4];
+        uint8_t uart_port;
+        uint8_t uart_rate;
+        uint8_t bist_enable;
+        uint8_t bist_gpio_pin_cfg;
+        uint8_t bist_gpio_level_cfg;
+        uint8_t rsvd2[3];
+        uint32_t xml_version;
+        uint32_t relocatable_img_len;
+        uint32_t link_addr;
+        uint32_t header_crc;
+};
+
 struct switchtec_fw_part_summary {
 	struct switchtec_fw_part_type {
 		struct switchtec_fw_image_info *active, *inactive;
@@ -342,6 +374,8 @@ int switchtec_event_ctl(struct switchtec_dev *dev,
 			int index, int flags,
 			uint32_t data[5]);
 int switchtec_event_wait(struct switchtec_dev *dev, int timeout_ms);
+int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
+                                  struct switchtec_fw_image_info *info);
 
 /*********** Generic Accessors ***********/
 

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -229,6 +229,9 @@ struct switchtec_fw_image_info {
 	size_t image_len;			//!< Length of the image
 	unsigned long image_crc;		//!< CRC checksum of the image
 
+	uint8_t public_key_modulus[512];	//!< Pub Key Mod of the image
+	uint8_t public_key_exponent[4];		//!< Pub Key Exp of the image
+
 	bool valid;
 	bool active;
 	bool running;
@@ -239,38 +242,6 @@ struct switchtec_fw_image_info {
 	void *metadata;
 
 	unsigned long secure_version;
-};
-
-struct switchtec_fw_metadata_gen4 {
-        char magic[4];
-        char sub_magic[4];
-        uint32_t hdr_version;
-        uint32_t secure_version;
-        uint32_t header_len;
-        uint32_t metadata_len;
-        uint32_t image_len;
-        uint32_t type;
-        uint32_t rsvd;
-        uint32_t version;
-        uint32_t sequence;
-        uint32_t reserved1;
-        uint8_t date_str[8];
-        uint8_t time_str[8];
-        uint8_t img_str[16];
-        uint8_t rsvd1[4];
-        uint32_t image_crc;
-        uint8_t public_key_modulus[512];
-        uint8_t public_key_exponent[4];
-        uint8_t uart_port;
-        uint8_t uart_rate;
-        uint8_t bist_enable;
-        uint8_t bist_gpio_pin_cfg;
-        uint8_t bist_gpio_level_cfg;
-        uint8_t rsvd2[3];
-        uint32_t xml_version;
-        uint32_t relocatable_img_len;
-        uint32_t link_addr;
-        uint32_t header_crc;
 };
 
 struct switchtec_fw_part_summary {

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -74,38 +74,6 @@ enum switchtec_fw_part_type_gen4 {
 	SWITCHTEC_FW_IMG_TYPE_UNKNOWN_GEN4,
 };
 
-struct switchtec_fw_metadata_gen4 {
-	char magic[4];
-	char sub_magic[4];
-	uint32_t hdr_version;
-	uint32_t secure_version;
-	uint32_t header_len;
-	uint32_t metadata_len;
-	uint32_t image_len;
-	uint32_t type;
-	uint32_t rsvd;
-	uint32_t version;
-	uint32_t sequence;
-	uint32_t reserved1;
-	uint8_t date_str[8];
-	uint8_t time_str[8];
-	uint8_t img_str[16];
-	uint8_t rsvd1[4];
-	uint32_t image_crc;
-	uint8_t public_key_modulus[512];
-	uint8_t public_key_exponent[4];
-	uint8_t uart_port;
-	uint8_t uart_rate;
-	uint8_t bist_enable;
-	uint8_t bist_gpio_pin_cfg;
-	uint8_t bist_gpio_level_cfg;
-	uint8_t rsvd2[3];
-	uint32_t xml_version;
-	uint32_t relocatable_img_len;
-	uint32_t link_addr;
-	uint32_t header_crc;
-};
-
 struct switchtec_fw_image_header_gen3 {
 	char magic[4];
 	uint32_t image_len;
@@ -1033,7 +1001,7 @@ static int switchtec_fw_part_info_gen4(struct switchtec_dev *dev,
  *	\p nr_info entries
  * @return number of part info on success, negative on failure
  */
-static int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
+int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
 				  struct switchtec_fw_image_info *info)
 {
 	int ret;

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -74,6 +74,38 @@ enum switchtec_fw_part_type_gen4 {
 	SWITCHTEC_FW_IMG_TYPE_UNKNOWN_GEN4,
 };
 
+struct switchtec_fw_metadata_gen4 {
+	char magic[4];
+	char sub_magic[4];
+	uint32_t hdr_version;
+	uint32_t secure_version;
+	uint32_t header_len;
+	uint32_t metadata_len;
+	uint32_t image_len;
+	uint32_t type;
+	uint32_t rsvd;
+	uint32_t version;
+	uint32_t sequence;
+	uint32_t reserved1;
+	uint8_t date_str[8];
+	uint8_t time_str[8];
+	uint8_t img_str[16];
+	uint8_t rsvd1[4];
+	uint32_t image_crc;
+	uint8_t public_key_modulus[512];
+	uint8_t public_key_exponent[4];
+	uint8_t uart_port;
+	uint8_t uart_rate;
+	uint8_t bist_enable;
+	uint8_t bist_gpio_pin_cfg;
+	uint8_t bist_gpio_level_cfg;
+	uint8_t rsvd2[3];
+	uint32_t xml_version;
+	uint32_t relocatable_img_len;
+	uint32_t link_addr;
+	uint32_t header_crc;
+};
+
 struct switchtec_fw_image_header_gen3 {
 	char magic[4];
 	uint32_t image_len;
@@ -886,6 +918,11 @@ static int switchtec_fw_info_metadata_gen4(struct switchtec_dev *dev,
 	inf->part_body_offset = le32toh(metadata->header_len);
 	inf->image_crc = le32toh(metadata->image_crc);
 	inf->image_len = le32toh(metadata->image_len);
+	inf->secure_version = le32toh(metadata->secure_version);
+	memcpy(inf->public_key_exponent, metadata->public_key_exponent,
+	      sizeof(metadata->public_key_exponent));
+	memcpy(inf->public_key_modulus, metadata->public_key_modulus,
+	      sizeof(metadata->public_key_modulus));
 	inf->metadata = metadata;
 
 	return 0;


### PR DESCRIPTION
This change is to add a new command "fw_meta_info" to get the Metadata information from the flash partitions. 

Changes include:
1. New function fw_meta_info() to handle the command. Metadata info is derived by calling the switchtec_fw_part_info() function that already exists in fw.c which gets the required info from the switch.
2. Helper function part_to_string() to convert partition ID to partition name string.
3. Add the definition of switchtec_fw_part_info() to switchtec.h file instead of it being a static function in fw.c.
4. Moved the structure switchtec_fw_metadata_gen4 from fw.c to switchtec.h

Thanks and Regards,
Rakesh Vitta