### PR TITLE
Enable sending 4K command data

### DIFF
--- a/inc/switchtec/fabric.h
+++ b/inc/switchtec/fabric.h
@@ -702,7 +702,7 @@ int switchtec_ep_bar_write64(struct switchtec_dev *dev, uint16_t pdfid,
 			     uint8_t bar_index, uint64_t val, uint64_t addr);
 
 /********** ADMIN PASSTHRU COMMAND *********/
-#define SWITCHTEC_NVME_ADMIN_PASSTHRU_MAX_DATA_LEN (MRPC_MAX_DATA_LEN - 8)
+#define SWITCHTEC_NVME_ADMIN_PASSTHRU_MAX_DATA_LEN (4096 + 16 * 4)
 
 int switchtec_nvme_admin_passthru(struct switchtec_dev *dev, uint16_t pdfid,
 				  size_t data_len, void *data,


### PR DESCRIPTION
In the previous implementation, data over 1016 bytes are truncated, due to MRPC data size limitation. 

In the new subcommand `MRPC_NVME_ADMIN_PASSTHRU_START` definition, a `more_data` field is added to indicate if there is more data to be sent for this transaction. This enables use to send command data of more than 1016 bytes in length.

A loop is added to iteratively send all data using this subcommand.