### PR TITLE
Bypass secure version checking for unsiged image

### DIFF
--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -239,6 +239,7 @@ struct switchtec_fw_image_info {
 	void *metadata;
 
 	unsigned long secure_version;
+	bool signed_image;
 };
 
 struct switchtec_fw_part_summary {

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -603,6 +603,7 @@ static int switchtec_fw_file_info_gen3(int fd,
 	info->type = switchtec_fw_id_to_type(info);
 
 	info->secure_version = 0;
+	info->signed_image = 0;
 
 	return 0;
 
@@ -616,6 +617,7 @@ static int switchtec_fw_file_info_gen4(int fd,
 {
 	int ret;
 	struct switchtec_fw_metadata_gen4 hdr = {};
+	uint8_t exp_zero[4] = {};
 
 	ret = read(fd, &hdr, sizeof(hdr));
 	lseek(fd, 0, SEEK_SET);
@@ -667,6 +669,8 @@ static int switchtec_fw_file_info_gen4(int fd,
 	info->type = switchtec_fw_id_to_type(info);
 
 	info->secure_version = le32toh(hdr.secure_version);
+	info->signed_image = !!memcmp(hdr.public_key_exponent, exp_zero, 4);
+
 	return 0;
 
 invalid_file:

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -731,6 +731,9 @@ int switchtec_fw_file_secure_version_newer(struct switchtec_dev *dev,
 	if (ret)
 		return 0;
 
+	if (!info.signed_image)
+		return 0;
+
 	ret = switchtec_sn_ver_get(dev, &sn_info);
 	if (ret) {
 		sn_info.ver_bl2 = 0xffffffff;


### PR DESCRIPTION
Secure version checking compares image secure version to that of the device, and issue a warning if image secure version is higher.

For unsigned image, the image secure version has no effect, so for such images, we should bypass secure version checking.

We determine if an image is unsigned by checking the public_key_exponent field.