### PR TITLE
Fix 'temp' command for GEN5 device

### DIFF
--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -1396,11 +1396,6 @@ float switchtec_die_temp(struct switchtec_dev *dev)
 	uint32_t sub_cmd_id;
 	uint32_t temp;
 
-	if (!switchtec_is_gen3(dev) && !switchtec_is_gen4(dev)) {
-		errno = ENOTSUP;
-		return -100.0;
-	}
-
 	if (switchtec_is_gen3(dev)) {
 		sub_cmd_id = MRPC_DIETEMP_SET_MEAS;
 		ret = switchtec_cmd(dev, MRPC_DIETEMP, &sub_cmd_id,


### PR DESCRIPTION
GEN5 uses the same command as GEN4 to get chip temperature readings. 

Since the device GEN field is always known during initialization (otherwise program errors out), it is safe to delete the GEN3/GEN4 check.