### PR TITLE
Add support for fw-info/read command

### DIFF
--- a/lib/fw.c
+++ b/lib/fw.c
@@ -1495,7 +1495,8 @@ int switchtec_fw_img_write_hdr(int fd, struct switchtec_fw_image_info *info)
 {
 	switch (info->gen) {
 	case SWITCHTEC_GEN3: return switchtec_fw_img_write_hdr_gen3(fd, info);
-	case SWITCHTEC_GEN4: return switchtec_fw_img_write_hdr_gen4(fd, info);
+	case SWITCHTEC_GEN4:
+	case SWITCHTEC_GEN5: return switchtec_fw_img_write_hdr_gen4(fd, info);
 	default:
 		errno = EINVAL;
 		return -1;

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -1075,7 +1075,7 @@ static int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
 	if (info == NULL || nr_info == 0)
 		return -EINVAL;
 
-	if (dev->gen == SWITCHTEC_GEN4) {
+	if (dev->gen > SWITCHTEC_GEN3) {
 		ret = switchtec_cmd(dev, MRPC_PART_INFO, &subcmd,
 				    sizeof(subcmd), &all_info,
 				    sizeof(all_info));
@@ -1101,6 +1101,7 @@ static int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
 			ret = switchtec_fw_part_info_gen3(dev, inf);
 			break;
 		case SWITCHTEC_GEN4:
+		case SWITCHTEC_GEN5:
 			ret = switchtec_fw_part_info_gen4(dev, inf, &all_info);
 			break;
 		default:
@@ -1249,6 +1250,7 @@ switchtec_fw_part_summary(struct switchtec_dev *dev)
 		nr_info = ARRAY_SIZE(switchtec_fw_partitions_gen3);
 		break;
 	case SWITCHTEC_GEN4:
+	case SWITCHTEC_GEN5:
 		nr_info = ARRAY_SIZE(switchtec_fw_partitions_gen4);
 		break;
 	default:
@@ -1272,6 +1274,7 @@ switchtec_fw_part_summary(struct switchtec_dev *dev)
 				switchtec_fw_partitions_gen3[i];
 		break;
 	case SWITCHTEC_GEN4:
+	case SWITCHTEC_GEN5:
 		for (i = 0; i < nr_info; i++)
 			summary->all[i].part_id =
 				switchtec_fw_partitions_gen4[i];


### PR DESCRIPTION
Background: GEN5 uses the same MRPC commands for `fw-info` and `fw-read` command as GEN4 devices.

The PR adds support for GEN5 for `fw-info` and `fw-read` command.