### PR TITLE
Fix security settings for GEN5 devices

### DIFF
--- a/cli/mfg.c
+++ b/cli/mfg.c
@@ -64,11 +64,6 @@ static const struct argconfig_choice secure_state_choices[] = {
 	{}
 };
 
-static char *spi_rate_str[] = {
-	"100", "67", "50", "40", "33.33", "28.57",
-	"25", "22.22", "20", "18.18"
-};
-
 static const char* phase_id_to_string(enum switchtec_boot_phase phase_id)
 {
 	switch(phase_id) {
@@ -176,8 +171,7 @@ static void print_security_config(struct switchtec_security_cfg_state *state,
 	printf("\tJTAG/EJTAG Unlock AFTER BL1: \t%d\n",
 		state->jtag_post_bl1_unlock_allowed);
 
-	printf("\tSPI Clock Rate: \t\t%s MHz\n",
-		spi_rate_str[state->spi_clk_rate-1]);
+	printf("\tSPI Clock Rate: \t\t%.2f MHz\n", state->spi_clk_rate);
 
 	printf("\tI2C Recovery TMO: \t\t%d Second(s)\n",
 		state->i2c_recovery_tmo);
@@ -246,8 +240,7 @@ static void print_security_cfg_set(struct switchtec_security_cfg_set *set)
 	printf("\tJTAG/EJTAG Unlock AFTER BL1: \t%d\n",
 		set->jtag_post_bl1_unlock_allowed);
 
-	printf("\tSPI Clock Rate: \t\t%s MHz\n",
-		spi_rate_str[set->spi_clk_rate-1]);
+	printf("\tSPI Clock Rate: \t\t%.2f MHz\n", set->spi_clk_rate);
 
 	printf("\tI2C Recovery TMO: \t\t%d Second(s)\n",
 		set->i2c_recovery_tmo);
@@ -830,7 +823,8 @@ static int config_set(int argc, char **argv)
 		return -2;
 	}
 
-	ret = switchtec_read_sec_cfg_file(cfg.setting_fimg, &settings);
+	ret = switchtec_read_sec_cfg_file(cfg.dev, cfg.setting_fimg,
+					  &settings);
 	fclose(cfg.setting_fimg);
 	if (ret) {
 		fprintf(stderr, "Invalid secure setting file: %s!\n",

--- a/inc/switchtec/mfg.h
+++ b/inc/switchtec/mfg.h
@@ -32,6 +32,8 @@
 #define SWITCHTEC_KMSK_LEN	64
 #define SWITCHTEC_KMSK_NUM	4
 
+#define SWITCHTEC_SECURITY_SPI_RATE_MAX_NUM	16
+
 struct switchtec_sn_ver_info {
 	uint32_t chip_serial;
 	uint32_t ver_km;
@@ -155,12 +157,19 @@ struct switchtec_signature{
 	uint8_t signature[SWITCHTEC_SIG_LEN];
 };
 
+struct switchtec_security_spi_avail_rate {
+	int num_rates;
+	float rates[SWITCHTEC_SECURITY_SPI_RATE_MAX_NUM];
+};
+
 int switchtec_sn_ver_get(struct switchtec_dev *dev,
 			 struct switchtec_sn_ver_info *info);
 int switchtec_security_config_get(struct switchtec_dev *dev,
 			          struct switchtec_security_cfg_state *state);
 int switchtec_security_config_get_ext(struct switchtec_dev *dev,
 		struct switchtec_security_cfg_state_ext *ext);
+int switchtec_security_spi_avail_rate_get(struct switchtec_dev *dev,
+		struct switchtec_security_spi_avail_rate *rates);
 int switchtec_security_config_set(struct switchtec_dev *dev,
 				  struct switchtec_security_cfg_set *setting);
 int switchtec_mailbox_to_file(struct switchtec_dev *dev, int fd);

--- a/inc/switchtec/mfg.h
+++ b/inc/switchtec/mfg.h
@@ -52,19 +52,6 @@ enum switchtec_secure_state {
 	SWITCHTEC_SECURE_STATE_UNKNOWN = 0xff,
 };
 
-enum switchtec_spi_clk_rate {
-	SWITCHTEC_SPI_RATE_100M = 1,
-	SWITCHTEC_SPI_RATE_67M,
-	SWITCHTEC_SPI_RATE_50M,
-	SWITCHTEC_SPI_RATE_40M,
-	SWITCHTEC_SPI_RATE_33_33M,
-	SWITCHTEC_SPI_RATE_28_57M,
-	SWITCHTEC_SPI_RATE_25M,
-	SWITCHTEC_SPI_RATE_22_22M,
-	SWITCHTEC_SPI_RATE_20M,
-	SWITCHTEC_SPI_RATE_18_18M
-};
-
 struct switchtec_security_cfg_state {
 	uint8_t basic_setting_valid;
 	uint8_t public_key_exp_valid;
@@ -80,7 +67,7 @@ struct switchtec_security_cfg_state {
 	uint8_t jtag_bl1_unlock_allowed;
 	uint8_t jtag_post_bl1_unlock_allowed;
 
-	enum switchtec_spi_clk_rate spi_clk_rate;
+	float spi_clk_rate;
 	uint32_t i2c_recovery_tmo;
 	uint32_t i2c_port;
 	uint32_t i2c_addr;
@@ -128,7 +115,7 @@ struct switchtec_security_cfg_set {
 	uint8_t jtag_bl1_unlock_allowed;
 	uint8_t jtag_post_bl1_unlock_allowed;
 
-	uint32_t spi_clk_rate;
+	float spi_clk_rate;
 	uint32_t i2c_recovery_tmo;
 	uint32_t i2c_port;
 	uint32_t i2c_addr;
@@ -199,8 +186,9 @@ int switchtec_dbg_unlock_version_update(struct switchtec_dev *dev,
 					uint32_t ver_sec_unlock,
 					struct switchtec_pubkey *public_key,
 			 		struct switchtec_signature *signature);
-int switchtec_read_sec_cfg_file(FILE *setting_file,
-			        struct switchtec_security_cfg_set *set);
+int switchtec_read_sec_cfg_file(struct switchtec_dev *dev,
+				FILE *setting_file,
+				struct switchtec_security_cfg_set *set);
 int switchtec_read_pubk_file(FILE *pubk_file, struct switchtec_pubkey *pubk);
 int switchtec_read_kmsk_file(FILE *kmsk_file, struct switchtec_kmsk *kmsk);
 int switchtec_read_signature_file(FILE *sig_file,

--- a/inc/switchtec/mrpc.h
+++ b/inc/switchtec/mrpc.h
@@ -91,6 +91,7 @@ enum mrpc_cmd {
 	MRPC_DBG_UNLOCK = 266,
 	MRPC_BOOTUP_RESUME = 267,
 	MRPC_SECURITY_CONFIG_GET_GEN5 = 268,
+	MRPC_SECURITY_CONFIG_SET_GEN5 = 269,
 };
 
 enum mrpc_bg_status {

--- a/inc/switchtec/mrpc.h
+++ b/inc/switchtec/mrpc.h
@@ -90,6 +90,7 @@ enum mrpc_cmd {
 	MRPC_SN_VER_GET = 265,
 	MRPC_DBG_UNLOCK = 266,
 	MRPC_BOOTUP_RESUME = 267,
+	MRPC_SECURITY_CONFIG_GET_GEN5 = 268,
 };
 
 enum mrpc_bg_status {

--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -367,6 +367,7 @@ int switchtec_security_config_set(struct switchtec_dev *dev,
 	uint32_t map_shift;
 	uint32_t map_mask;
 	int spi_clk;
+	uint8_t cmd_buf[20] = {};
 
 	ret = get_configs(dev, &reply);
 	if (ret)
@@ -411,8 +412,15 @@ int switchtec_security_config_set(struct switchtec_dev *dev,
 
 	sd.pub_key_exponent = htole32(setting->public_key_exponent);
 
-	ret = switchtec_mfg_cmd(dev, MRPC_SECURITY_CONFIG_SET, &sd, sizeof(sd),
-				NULL, 0);
+	if (switchtec_gen(dev) == SWITCHTEC_GEN4) {
+		ret = switchtec_mfg_cmd(dev, MRPC_SECURITY_CONFIG_SET,
+					&sd, sizeof(sd), NULL, 0);
+	} else {
+		cmd_buf[0] = 1;
+		memcpy(cmd_buf + 4, &sd, sizeof(sd));
+		ret = switchtec_mfg_cmd(dev, MRPC_SECURITY_CONFIG_SET_GEN5,
+					cmd_buf, sizeof(cmd_buf), NULL, 0);
+	}
 	return ret;
 }
 

--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -169,6 +169,27 @@ static int get_configs(struct switchtec_dev *dev, struct get_cfgs_reply *cfgs)
 	return ret;
 }
 
+int switchtec_security_spi_avail_rate_get(struct switchtec_dev *dev,
+		struct switchtec_security_spi_avail_rate *rates)
+{
+	int ret;
+	struct get_cfgs_reply reply;
+
+	ret = get_configs(dev, &reply);
+	if (ret)
+		return ret;
+
+	rates->num_rates = 10;
+	if (reply.spi_core_clk_high)
+		memcpy(rates->rates, spi_clk_hi_rate_float,
+		       sizeof(spi_clk_hi_rate_float));
+	else
+		memcpy(rates->rates, spi_clk_rate_float,
+		       sizeof(spi_clk_rate_float));
+
+	return 0;
+}
+
 static int secure_config_get(struct switchtec_dev *dev,
 			     struct switchtec_security_cfg_state *state,
 			     struct switchtec_security_cfg_otp_region *otp,

--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -238,8 +238,12 @@ static int secure_config_get(struct switchtec_dev *dev,
 	state->jtag_post_bl1_unlock_allowed = !!(reply.cfg & 0x0200);
 
 	spi_clk = (reply.cfg >> SWITCHTEC_CLK_RATE_BITSHIFT) & 0x0f;
-	if (spi_clk == 0)
-		spi_clk = 7;
+	if (spi_clk == 0) {
+		if (switchtec_gen(dev) == SWITCHTEC_GEN5)
+			spi_clk = 9;
+		else
+			spi_clk = 7;
+	}
 
 	if (reply.spi_core_clk_high)
 		state->spi_clk_rate = spi_clk_hi_rate_float[spi_clk - 1];

--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -163,8 +163,17 @@ static int secure_config_get(struct switchtec_dev *dev,
 				*otp_valid = true;
 		}
 	} else {
-		ret = switchtec_mfg_cmd(dev, MRPC_SECURITY_CONFIG_GET, NULL, 0,
-					&reply, sizeof(reply));
+		if (switchtec_gen(dev) == SWITCHTEC_GEN5) {
+			subcmd = 1;
+			ret = switchtec_mfg_cmd(dev,
+						MRPC_SECURITY_CONFIG_GET_GEN5,
+						&subcmd, sizeof(subcmd),
+						&reply, sizeof(reply));
+		} else {
+			ret = switchtec_mfg_cmd(dev, MRPC_SECURITY_CONFIG_GET,
+						NULL, 0, &reply,
+						sizeof(reply));
+		}
 		if (ret)
 			return ret;
 	}

--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -53,6 +53,7 @@ static const char gasop_noretry_cmds[] = {
 	[MRPC_SECURE_STATE_SET] = 1,
 	[MRPC_BOOTUP_RESUME] = 1,
 	[MRPC_DBG_UNLOCK] = 1,
+	[MRPC_SECURITY_CONFIG_SET_GEN5] = 1,
 };
 static const int gasop_noretry_cmds_count = sizeof(gasop_noretry_cmds) /
 					    sizeof(char);


### PR DESCRIPTION
Background: GEN5 device uses a different MRPC command to read chip security settings.  The security settings of GEN5 are different from GEN4 devices in the following:
- I2C address changes from 7-bit to 8-bit
- I2C command map starting bits changes from bit 29 to bit 30
- I2C command map is now 14-bit long, instead of 12-bit in GEN4
- Adds "SPI clock rate high" field (a reserved field, always 0 on GEN4) to indicate that SPI is running in 'turbo' mode

In this PR, we submit the following changes:
- Add function to get I2C address and command map operands (bit shift, bit mask) based on device generation
- Add `gen` field to security setting structure so I2C address can display accordingly
- Add `spi_core_clk_high` to security setting structure so SPI clock rate can display accordingly
