### PR TITLE
Check device generation in security setting file

### DIFF
--- a/cli/mfg.c
+++ b/cli/mfg.c
@@ -826,10 +826,15 @@ static int config_set(int argc, char **argv)
 	ret = switchtec_read_sec_cfg_file(cfg.dev, cfg.setting_fimg,
 					  &settings);
 	fclose(cfg.setting_fimg);
-	if (ret) {
+	if (ret == -EBADF) {
 		fprintf(stderr, "Invalid secure setting file: %s!\n",
 			cfg.setting_file);
 		return -3;
+	} else if (ret == -ENODEV) {
+		fprintf(stderr, "The security setting file is for a different generation of Switchtec device!\n");
+		return -5;
+	} else {
+		switchtec_perror("mfg config-set");
 	}
 
 	printf("Writing the below settings to device: \n");

--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -744,6 +744,9 @@ int switchtec_read_sec_cfg_file(struct switchtec_dev *dev,
 		return -EBADF;
 	}
 
+	if (gen != switchtec_gen(dev))
+		return -ENODEV;
+
 	memset(set, 0, sizeof(struct switchtec_security_cfg_set));
 
 	file_data.data.cfg = le64toh(file_data.data.cfg);


### PR DESCRIPTION
Add checks to ensure that the  `generation` flag in the security setting file matches that of the current device.