### PR TITLE
Fix OTP status get/display for Gen5

### DIFF
--- a/cli/mfg.c
+++ b/cli/mfg.c
@@ -306,7 +306,8 @@ static int info(int argc, char **argv)
 			print_security_config(&state, NULL);
 			fprintf(stderr,
 				"\nAdditional (verbose) chip info is not available on this chip!\n\n");
-		} else if (phase_id != SWITCHTEC_BOOT_PHASE_FW) {
+		} else if (switchtec_gen(cfg.dev) == SWITCHTEC_GEN4 &&
+			   phase_id != SWITCHTEC_BOOT_PHASE_FW) {
 			print_security_config(&state, NULL);
 			fprintf(stderr,
 				"\nAdditional (verbose) chip info is only available in the Main Firmware phase!\n\n");

--- a/cli/mfg.c
+++ b/cli/mfg.c
@@ -272,11 +272,11 @@ static int info(int argc, char **argv)
 		 "print additional chip information"},
 		{NULL}};
 
-	struct switchtec_security_cfg_state_ext ext_state = {};
+	struct switchtec_security_cfg_state state;
 
 	argconfig_parse(argc, argv, CMD_DESC_INFO, opts, &cfg, sizeof(cfg));
 
-	ret = switchtec_security_config_get_ext(cfg.dev, &ext_state);
+	ret = switchtec_security_config_get(cfg.dev, &state);
 	if (ret) {
 		switchtec_perror("mfg info");
 		return ret;
@@ -302,22 +302,22 @@ static int info(int argc, char **argv)
 	}
 
 	if (cfg.verbose)  {
-		if (!ext_state.otp_valid) {
-			print_security_config(&ext_state.state, NULL);
+		if (!state.otp_valid) {
+			print_security_config(&state, NULL);
 			fprintf(stderr,
 				"\nAdditional (verbose) chip info is not available on this chip!\n\n");
 		} else if (phase_id != SWITCHTEC_BOOT_PHASE_FW) {
-			print_security_config(&ext_state.state, NULL);
+			print_security_config(&state, NULL);
 			fprintf(stderr,
 				"\nAdditional (verbose) chip info is only available in the Main Firmware phase!\n\n");
 		} else {
-			print_security_config(&ext_state.state, &ext_state.otp);
+			print_security_config(&state, &state.otp);
 		}
 
 		return 0;
 	}
 
-	print_security_config(&ext_state.state, NULL);
+	print_security_config(&state, NULL);
 
 	return 0;
 }

--- a/inc/switchtec/mfg.h
+++ b/inc/switchtec/mfg.h
@@ -54,6 +54,27 @@ enum switchtec_secure_state {
 	SWITCHTEC_SECURE_STATE_UNKNOWN = 0xff,
 };
 
+/**
+ * @brief Flag which indicates if an OTP region is programmable or not
+ */
+enum switchtec_otp_program_status {
+	SWITCHTEC_OTP_PROGRAMMABLE = 0,
+	SWITCHTEC_OTP_UNPROGRAMMABLE = 1,
+};
+
+struct switchtec_security_cfg_otp_region {
+	bool basic_valid;
+	bool mixed_ver_valid;
+	bool main_fw_ver_valid;
+	bool sec_unlock_ver_valid;
+	bool kmsk_valid[4];
+	enum switchtec_otp_program_status basic;
+	enum switchtec_otp_program_status mixed_ver;
+	enum switchtec_otp_program_status main_fw_ver;
+	enum switchtec_otp_program_status sec_unlock_ver;
+	enum switchtec_otp_program_status kmsk[4];
+};
+
 struct switchtec_security_cfg_state {
 	uint8_t basic_setting_valid;
 	uint8_t public_key_exp_valid;
@@ -79,35 +100,8 @@ struct switchtec_security_cfg_state {
 	uint32_t public_key_ver;
 
 	uint8_t public_key[SWITCHTEC_KMSK_NUM][SWITCHTEC_KMSK_LEN];
-};
 
-/**
- * @brief Flag which indicates if an OTP region is programmable or not
- */
-enum switchtec_otp_program_status {
-	SWITCHTEC_OTP_PROGRAMMABLE = 0,
-	SWITCHTEC_OTP_UNPROGRAMMABLE = 1,
-};
-
-struct switchtec_security_cfg_otp_region {
-	bool basic_valid;
-	bool mixed_ver_valid;
-	bool main_fw_ver_valid;
-	bool sec_unlock_ver_valid;
-	bool kmsk_valid[4];
-	enum switchtec_otp_program_status basic;
-	enum switchtec_otp_program_status mixed_ver;
-	enum switchtec_otp_program_status main_fw_ver;
-	enum switchtec_otp_program_status sec_unlock_ver;
-	enum switchtec_otp_program_status kmsk[4];
-};
-
-/**
- * @brief extended security configuration
- */
-struct switchtec_security_cfg_state_ext {
 	bool otp_valid;
-	struct switchtec_security_cfg_state state;
 	struct switchtec_security_cfg_otp_region otp;
 };
 
@@ -166,8 +160,6 @@ int switchtec_sn_ver_get(struct switchtec_dev *dev,
 			 struct switchtec_sn_ver_info *info);
 int switchtec_security_config_get(struct switchtec_dev *dev,
 			          struct switchtec_security_cfg_state *state);
-int switchtec_security_config_get_ext(struct switchtec_dev *dev,
-		struct switchtec_security_cfg_state_ext *ext);
 int switchtec_security_spi_avail_rate_get(struct switchtec_dev *dev,
 		struct switchtec_security_spi_avail_rate *rates);
 int switchtec_security_config_set(struct switchtec_dev *dev,

--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -190,10 +190,14 @@ int switchtec_security_spi_avail_rate_get(struct switchtec_dev *dev,
 	return 0;
 }
 
-static int secure_config_get(struct switchtec_dev *dev,
-			     struct switchtec_security_cfg_state *state,
-			     struct switchtec_security_cfg_otp_region *otp,
-			     bool *otp_valid)
+/**
+ * @brief Get secure boot configurations
+ * @param[in]  dev	Switchtec device handle
+ * @param[out] state	Current secure boot settings
+ * @return 0 on success, error code on failure
+ */
+int switchtec_security_config_get(struct switchtec_dev *dev,
+				  struct switchtec_security_cfg_state *state)
 {
 	int ret;
 	uint8_t subcmd = 0;
@@ -203,8 +207,7 @@ static int secure_config_get(struct switchtec_dev *dev,
 	int spi_clk;
 	struct get_cfgs_reply reply;
 
-	if (otp_valid)
-		*otp_valid = false;
+	state->otp_valid = false;
 
 	ret = switchtec_mfg_cmd(dev, MRPC_SECURITY_CONFIG_GET_EXT,
 				&subcmd, sizeof(subcmd),
@@ -213,27 +216,24 @@ static int secure_config_get(struct switchtec_dev *dev,
 		return ret;
 
 	if (!ret) {
-		if (otp) {
-			otp->basic_valid = !!(reply.valid & BIT(5));
-			otp->basic = !!(reply.valid & BIT(6));
-			otp->mixed_ver_valid = !!(reply.valid & BIT(7));
-			otp->mixed_ver = !!(reply.valid & BIT(8));
-			otp->main_fw_ver_valid = !!(reply.valid & BIT(9));
-			otp->main_fw_ver = !!(reply.valid & BIT(10));
-			otp->sec_unlock_ver_valid = !!(reply.valid & BIT(11));
-			otp->sec_unlock_ver = !!(reply.valid & BIT(12));
-			otp->kmsk_valid[0] = !!(reply.valid & BIT(13));
-			otp->kmsk[0] = !!(reply.valid & BIT(14));
-			otp->kmsk_valid[1] = !!(reply.valid & BIT(15));
-			otp->kmsk[1] = !!(reply.valid & BIT(16));
-			otp->kmsk_valid[2] = !!(reply.valid & BIT(17));
-			otp->kmsk[2] = !!(reply.valid & BIT(18));
-			otp->kmsk_valid[3] = !!(reply.valid & BIT(19));
-			otp->kmsk[3] = !!(reply.valid & BIT(20));
+		state->otp.basic_valid = !!(reply.valid & BIT(5));
+		state->otp.basic = !!(reply.valid & BIT(6));
+		state->otp.mixed_ver_valid = !!(reply.valid & BIT(7));
+		state->otp.mixed_ver = !!(reply.valid & BIT(8));
+		state->otp.main_fw_ver_valid = !!(reply.valid & BIT(9));
+		state->otp.main_fw_ver = !!(reply.valid & BIT(10));
+		state->otp.sec_unlock_ver_valid = !!(reply.valid & BIT(11));
+		state->otp.sec_unlock_ver = !!(reply.valid & BIT(12));
+		state->otp.kmsk_valid[0] = !!(reply.valid & BIT(13));
+		state->otp.kmsk[0] = !!(reply.valid & BIT(14));
+		state->otp.kmsk_valid[1] = !!(reply.valid & BIT(15));
+		state->otp.kmsk[1] = !!(reply.valid & BIT(16));
+		state->otp.kmsk_valid[2] = !!(reply.valid & BIT(17));
+		state->otp.kmsk[2] = !!(reply.valid & BIT(18));
+		state->otp.kmsk_valid[3] = !!(reply.valid & BIT(19));
+		state->otp.kmsk[3] = !!(reply.valid & BIT(20));
 
-			if (otp_valid)
-				*otp_valid = true;
-		}
+		state->otp_valid = true;
 	} else {
 		ret = get_configs(dev, &reply);
 		if (ret)
@@ -288,30 +288,6 @@ static int secure_config_get(struct switchtec_dev *dev,
 	       SWITCHTEC_KMSK_NUM * SWITCHTEC_KMSK_LEN);
 
 	return 0;
-}
-
-/**
- * @brief Get secure boot configurations
- * @param[in]  dev	Switchtec device handle
- * @param[out] state	Current secure boot settings
- * @return 0 on success, error code on failure
- */
-int switchtec_security_config_get(struct switchtec_dev *dev,
-				  struct switchtec_security_cfg_state *state)
-{
-	return secure_config_get(dev, state, NULL, NULL);
-}
-
-/**
- * @brief Get secure boot extended configurations
- * @param[in]  dev	Switchtec device handle
- * @param[out] ext	Current extended secure boot settings
- * @return 0 on success, error code on failure
- */
-int switchtec_security_config_get_ext(struct switchtec_dev *dev,
-		struct switchtec_security_cfg_state_ext *ext)
-{
-	return secure_config_get(dev, &ext->state, &ext->otp, &ext->otp_valid);
 }
 
 /**

--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -149,7 +149,9 @@ struct get_cfgs_reply {
 	uint8_t rsvd4[32];
 };
 
-static int get_configs(struct switchtec_dev *dev, struct get_cfgs_reply *cfgs)
+static int get_configs(struct switchtec_dev *dev,
+		       struct get_cfgs_reply *cfgs,
+		       int *otp_valid)
 {
 	uint8_t subcmd = 0;
 	int ret;
@@ -160,7 +162,21 @@ static int get_configs(struct switchtec_dev *dev, struct get_cfgs_reply *cfgs)
 					MRPC_SECURITY_CONFIG_GET_GEN5,
 					&subcmd, sizeof(subcmd),
 					cfgs, sizeof(struct get_cfgs_reply));
+		if (!ret)
+			*otp_valid = true;
 	} else {
+		ret = switchtec_mfg_cmd(dev, MRPC_SECURITY_CONFIG_GET_EXT,
+					&subcmd, sizeof(subcmd),
+					cfgs, sizeof(struct get_cfgs_reply));
+		if (ret && ERRNO_MRPC(errno) != ERR_CMD_INVALID)
+			return ret;
+
+		if (!ret) {
+			*otp_valid = true;
+			return ret;
+		}
+
+		*otp_valid = false;
 		ret = switchtec_mfg_cmd(dev, MRPC_SECURITY_CONFIG_GET,
 					NULL, 0, cfgs,
 					sizeof(struct get_cfgs_reply));
@@ -174,8 +190,9 @@ int switchtec_security_spi_avail_rate_get(struct switchtec_dev *dev,
 {
 	int ret;
 	struct get_cfgs_reply reply;
+	int otp_valid;
 
-	ret = get_configs(dev, &reply);
+	ret = get_configs(dev, &reply, &otp_valid);
 	if (ret)
 		return ret;
 
@@ -190,6 +207,27 @@ int switchtec_security_spi_avail_rate_get(struct switchtec_dev *dev,
 	return 0;
 }
 
+static void parse_otp_settings(struct switchtec_security_cfg_otp_region *otp,
+			       uint32_t flags)
+{
+	otp->basic_valid = !!(flags & BIT(5));
+	otp->basic = !!(flags & BIT(6));
+	otp->mixed_ver_valid = !!(flags & BIT(7));
+	otp->mixed_ver = !!(flags & BIT(8));
+	otp->main_fw_ver_valid = !!(flags & BIT(9));
+	otp->main_fw_ver = !!(flags & BIT(10));
+	otp->sec_unlock_ver_valid = !!(flags & BIT(11));
+	otp->sec_unlock_ver = !!(flags & BIT(12));
+	otp->kmsk_valid[0] = !!(flags & BIT(13));
+	otp->kmsk[0] = !!(flags & BIT(14));
+	otp->kmsk_valid[1] = !!(flags & BIT(15));
+	otp->kmsk[1] = !!(flags & BIT(16));
+	otp->kmsk_valid[2] = !!(flags & BIT(17));
+	otp->kmsk[2] = !!(flags & BIT(18));
+	otp->kmsk_valid[3] = !!(flags & BIT(19));
+	otp->kmsk[3] = !!(flags & BIT(20));
+}
+
 /**
  * @brief Get secure boot configurations
  * @param[in]  dev	Switchtec device handle
@@ -200,45 +238,16 @@ int switchtec_security_config_get(struct switchtec_dev *dev,
 				  struct switchtec_security_cfg_state *state)
 {
 	int ret;
-	uint8_t subcmd = 0;
 	uint32_t addr_shift;
 	uint32_t map_shift;
 	uint32_t map_mask;
 	int spi_clk;
 	struct get_cfgs_reply reply;
+	int otp_valid;
 
-	state->otp_valid = false;
-
-	ret = switchtec_mfg_cmd(dev, MRPC_SECURITY_CONFIG_GET_EXT,
-				&subcmd, sizeof(subcmd),
-				&reply, sizeof(reply));
-	if (ret && ERRNO_MRPC(errno) != ERR_CMD_INVALID)
+	ret = get_configs(dev, &reply, &otp_valid);
+	if (ret)
 		return ret;
-
-	if (!ret) {
-		state->otp.basic_valid = !!(reply.valid & BIT(5));
-		state->otp.basic = !!(reply.valid & BIT(6));
-		state->otp.mixed_ver_valid = !!(reply.valid & BIT(7));
-		state->otp.mixed_ver = !!(reply.valid & BIT(8));
-		state->otp.main_fw_ver_valid = !!(reply.valid & BIT(9));
-		state->otp.main_fw_ver = !!(reply.valid & BIT(10));
-		state->otp.sec_unlock_ver_valid = !!(reply.valid & BIT(11));
-		state->otp.sec_unlock_ver = !!(reply.valid & BIT(12));
-		state->otp.kmsk_valid[0] = !!(reply.valid & BIT(13));
-		state->otp.kmsk[0] = !!(reply.valid & BIT(14));
-		state->otp.kmsk_valid[1] = !!(reply.valid & BIT(15));
-		state->otp.kmsk[1] = !!(reply.valid & BIT(16));
-		state->otp.kmsk_valid[2] = !!(reply.valid & BIT(17));
-		state->otp.kmsk[2] = !!(reply.valid & BIT(18));
-		state->otp.kmsk_valid[3] = !!(reply.valid & BIT(19));
-		state->otp.kmsk[3] = !!(reply.valid & BIT(20));
-
-		state->otp_valid = true;
-	} else {
-		ret = get_configs(dev, &reply);
-		if (ret)
-			return ret;
-	}
 
 	reply.valid = le32toh(reply.valid);
 	reply.cfg = le64toh(reply.cfg);
@@ -249,6 +258,10 @@ int switchtec_security_config_get(struct switchtec_dev *dev,
 	state->public_key_num_valid = !!(reply.valid & 0x04);
 	state->public_key_ver_valid = !!(reply.valid & 0x08);
 	state->public_key_valid = !!(reply.valid & 0x10);
+
+	state->otp_valid = otp_valid;
+	if (otp_valid)
+		parse_otp_settings(&state->otp, reply.valid);
 
 	state->debug_mode = reply.cfg & 0x03;
 	state->secure_state = (reply.cfg>>2) & 0x03;
@@ -365,8 +378,9 @@ int switchtec_security_config_set(struct switchtec_dev *dev,
 	uint32_t map_mask;
 	int spi_clk;
 	uint8_t cmd_buf[20] = {};
+	int otp_valid;
 
-	ret = get_configs(dev, &reply);
+	ret = get_configs(dev, &reply, &otp_valid);
 	if (ret)
 		return ret;
 
@@ -692,8 +706,9 @@ int switchtec_read_sec_cfg_file(struct switchtec_dev *dev,
 	enum switchtec_gen gen;
 	int spi_clk;
 	int ret;
+	int otp_valid;
 
-	ret = get_configs(dev, &reply);
+	ret = get_configs(dev, &reply, &otp_valid);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
This PR contains the following changes:
- merge `switchtec_security_cfg_otp_region` structure into `switchtec_security_cfg_state`, so a `switchtec_security_config_get` returns both security setting and OTP status
- delete redundant `switchtec_security_config_get_ext` function and associated data structures
- fix OTP status get/display for Gen5: Gen5 returns OTP settings in `MRPC_SECURITY_CONFIG_GET_GEN5` command reply, so we can parse OTP status from there