### PR TITLE
Add Gen and HW revision info to mfg ping command output

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -177,6 +177,7 @@ static int print_dev_info(struct switchtec_dev *dev)
 	int ret;
 	int device_id;
 	char version[64];
+	enum switchtec_rev hw_rev;
 
 	device_id = switchtec_device_id(dev);
 
@@ -186,8 +187,15 @@ static int print_dev_info(struct switchtec_dev *dev)
 		return ret;
 	}
 
+	ret = switchtec_get_device_info(dev, NULL, NULL, &hw_rev);
+	if (ret) {
+		switchtec_perror("dev info");
+		return ret;
+	}
+
 	printf("%s:\n", switchtec_name(dev));
 	printf("    Generation:  %s\n", switchtec_gen_str(dev));
+	printf("    HW Revision: %s\n", switchtec_rev_str(hw_rev));
 	printf("    Variant:     %s\n", switchtec_variant_str(dev));
 	printf("    Device ID:   0x%04x\n", device_id);
 	printf("    FW Version:  %s\n", version);

--- a/cli/mfg.c
+++ b/cli/mfg.c
@@ -83,7 +83,6 @@ static const char* phase_id_to_string(enum switchtec_boot_phase phase_id)
 static int ping(int argc, char **argv)
 {
 	int ret;
-	enum switchtec_boot_phase phase_id;
 	static struct {
 		struct switchtec_dev *dev;
 	} cfg = {};
@@ -94,14 +93,13 @@ static int ping(int argc, char **argv)
 
 	argconfig_parse(argc, argv, CMD_DESC_PING, opts, &cfg, sizeof(cfg));
 
-	ret = switchtec_get_device_info(cfg.dev, &phase_id, NULL, NULL);
+	ret = switchtec_get_device_info(cfg.dev, NULL, NULL, NULL);
 	if (ret) {
 		switchtec_perror("mfg ping");
 		return ret;
 	}
 
 	printf("Mfg Ping: \t\tSUCCESS\n");
-	printf("Current Boot Phase: \t%s\n", phase_id_to_string(phase_id));
 
 	return 0;
 }

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -491,6 +491,20 @@ static inline const char *switchtec_gen_str(struct switchtec_dev *dev)
 }
 
 /**
+ * @brief Return the revision string
+ */
+static inline const char *switchtec_rev_str(enum switchtec_rev rev)
+{
+	const char *str;
+
+	str =  (rev == SWITCHTEC_REVA) ? "REVA" :
+	       (rev == SWITCHTEC_REVB) ? "REVB" :
+	       (rev == SWITCHTEC_REVC) ? "REVC" : "Unknown";
+
+	return str;
+}
+
+/**
  * @brief Return the generation string of a Switchtec fw image.
  */
 static inline const char *

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -1381,7 +1381,7 @@ int switchtec_get_device_info(struct switchtec_dev *dev,
 			*rev = (dev_info >> 8) & 0x0f;
 		if (gen)
 			*gen = map_to_gen((dev_info >> 12) & 0x0f);
-	} else if (ERRNO_MRPC(errno) == ERR_MPRC_UNSUPPORTED) {
+	} else if (ERRNO_MRPC(errno) == ERR_CMD_INVALID) {
 		if (phase)
 			*phase = SWITCHTEC_BOOT_PHASE_FW;
 		if (gen)


### PR DESCRIPTION
Add HW revision and generation info to 'mfg ping' command output. 