### PR TITLE
Implement switchtec_list_free

### DIFF
--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -324,6 +324,7 @@ struct switchtec_dev *switchtec_open_eth(const char *ip, const int inst);
 
 void switchtec_close(struct switchtec_dev *dev);
 int switchtec_list(struct switchtec_device_info **devlist);
+void switchtec_list_free(struct switchtec_device_info *devlist);
 int switchtec_get_fw_version(struct switchtec_dev *dev, char *buf,
 			     size_t buflen);
 int switchtec_cmd(struct switchtec_dev *dev, uint32_t cmd,

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -195,6 +195,15 @@ static int set_local_pax_id(struct switchtec_dev *dev)
 }
 
 /**
+ * @brief Free a list of device info structures allocated by switchtec_list()
+ * @param[in] devlist switchtec_device_info structure list as returned by switchtec_list()
+ */
+void switchtec_list_free(struct switchtec_device_info *devlist)
+{
+	free(devlist);
+}
+
+/**
  * @brief Open a Switchtec device by string
  * @param[in] device A string representing the device to open
  * @return A switchtec_dev structure for use in other library functions


### PR DESCRIPTION
switchtech_list() returns a pointer allocated by switchtec.dll calloc().  I'm using the MSVC toolchain to call switchtec.dll and there is no way to free the returned memory since calling free() from my code will attempt to free the block using a different heap.  This PR add a library function that will free the memory using the switchec.dll free().