### PR TITLE
Fixed invalid pointer in cli list when no devices found

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -137,7 +137,7 @@ int pax_handler(const char *optarg, void *value_addr,
 
 static int list(int argc, char **argv)
 {
-	struct switchtec_device_info *devices;
+	struct switchtec_device_info *devices = NULL;
 	int i, n;
 
 	static struct {
@@ -152,7 +152,7 @@ static int list(int argc, char **argv)
 	argconfig_parse(argc, argv, CMD_DESC_LIST, opts, &cfg, sizeof(cfg));
 
 	n = switchtec_list(&devices);
-	if (n < 0)
+	if (n <= 0)
 		return n;
 
 	for (i = 0; i < n; i++) {


### PR DESCRIPTION
This patch initialized the devices pointer in list() in cli/main.c NULL to prevent a errors when freeing the list when no devices were found.