### PR TITLE
Fix fw-read segmentation fault

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1778,11 +1778,14 @@ static int fw_read(int argc, char **argv)
 		goto close_and_exit;
 	}
 
-	fprintf(stderr, "Version:  %s\n", inf->version);
-	fprintf(stderr, "Type:     %s\n",
-		cfg.data ? "DAT" : cfg.bl2? "BL2" : cfg.key? "KEY" : "IMG");
-	fprintf(stderr, "Img Len:  0x%x\n", (int)inf->image_len);
-	fprintf(stderr, "CRC:      0x%x\n", (int)inf->image_crc);
+	if (inf->valid) {
+		fprintf(stderr, "Version:  %s\n", inf->version);
+		fprintf(stderr, "Type:     %s\n",
+			cfg.data ? "DAT" : cfg.bl2? "BL2" :
+			cfg.key? "KEY" : "IMG");
+		fprintf(stderr, "Img Len:  0x%x\n", (int)inf->image_len);
+		fprintf(stderr, "CRC:      0x%x\n", (int)inf->image_crc);
+	}
 
 	if (!inf->valid && !cfg.assume_yes) {
 		fprintf(stderr,

--- a/cli/main.c
+++ b/cli/main.c
@@ -1771,6 +1771,13 @@ static int fw_read(int argc, char **argv)
 	else
 		inf = cfg.inactive ? sum->img.inactive : sum->img.active;
 
+	if (!inf) {
+		fprintf(stderr,
+			"The specified partition on the flash is empty!\n");
+		ret = -1;
+		goto close_and_exit;
+	}
+
 	fprintf(stderr, "Version:  %s\n", inf->version);
 	fprintf(stderr, "Type:     %s\n",
 		cfg.data ? "DAT" : cfg.bl2? "BL2" : cfg.key? "KEY" : "IMG");


### PR DESCRIPTION
Added the following checks:
- ensure the partition is not empty 
- only print the partition info if the partition is valid (avoid possible issues caused by random data on the flash)