### PR TITLE
Header and version check in log-parse command

### DIFF
--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -208,6 +208,16 @@ enum switchtec_log_parse_type {
 };
 
 /**
+ * @brief Information about log file and log definition file
+ */
+struct switchtec_log_file_ver_info {
+	unsigned int log_fw_version;
+	unsigned int log_sdk_version;
+	unsigned int def_fw_version;
+	unsigned int def_sdk_version;
+};
+
+/**
  * @brief Log definition data types
  */
 enum switchtec_log_def_type {
@@ -384,7 +394,8 @@ int switchtec_log_to_file(struct switchtec_dev *dev,
 			  FILE *log_def_file);
 int switchtec_parse_log(FILE *bin_log_file, FILE *log_def_file,
 			FILE *parsed_log_file,
-			enum switchtec_log_parse_type log_type);
+			enum switchtec_log_parse_type log_type,
+			struct switchtec_log_file_ver_info *info);
 int switchtec_log_def_to_file(struct switchtec_dev *dev,
 			      enum switchtec_log_def_type type,
 			      FILE* file);


### PR DESCRIPTION
**Background:** 
  The previous #266 adds a header to the binary log file generated from `log-dump` command. The header includes signature and version information.

**This PREP:**
- Updates `switchtec_parse_log` function to handle the header that _might_ exist in the input log file 
- Adds version checking to `log-parse` command, with a print to remind user when the input log file and log def file versions don't match