### PR TITLE
Fixed Windows error message with FW toggle command

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1807,7 +1807,10 @@ static int fw_toggle(int argc, char **argv)
 	printf("\n");
 
 	errno = err;
-	switchtec_perror("firmware toggle");
+	if (errno)
+		switchtec_perror("firmware toggle");
+	else
+		printf("firmware toggle: Success\n");
 
 	return ret;
 }


### PR DESCRIPTION
On windows, even when FW toggle succeeds, the error message is still seen as function call is made to platform_strerror().
It results in the following message: **The switchtec utility will show “firmware toggle: A device attached to the system is not functioning”.**

This is a false alarm.  To fix this issue, when the error number is 0, instead of making a function call to platform_strerror(), a 'Success' message is returned.

Code compilation details:
esdapps@esdapps-rome-2:~/error_msg/switchtec-user$ ./configure
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking for windres... no
checking for initscr in -lncurses... yes
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking curses.h usability... yes
checking curses.h presence... yes
checking for curses.h... yes
checking ncurses/curses.h usability... no
checking ncurses/curses.h presence... no
checking for ncurses/curses.h... no
checking openssl/pem.h usability... yes
checking openssl/pem.h presence... yes
checking for openssl/pem.h... yes
checking for RSA_free in -lcrypto... yes
checking whether RSA_get0_key is declared... yes
configure: creating ./config.status
config.status: creating Makefile
config.status: creating config.h
esdapps@esdapps-rome-2:~/error_msg/switchtec-user$ make
  VER   2.5
  CC    lib/mrpc.c
  CC    lib/fabric.c
  CC    lib/crc.c
  CC    lib/pmon.c
  CC    lib/fw.c
  CC    lib/gas_mrpc.c
  CC    lib/switchtec.c
  CC    lib/events.c
  CC    lib/diag.c
  CC    lib/mfg.c
  CC    lib/platform/platform.c
  CC    lib/platform/windows.c
  CC    lib/platform/linux-i2c.c
  CC    lib/platform/linux-uart.c
  CC    lib/platform/gasops.c
  CC    lib/platform/linux.c
  CC    lib/platform/linux-eth.c
  AR    libswitchtec.a
  LD    libswitchtec.so
  CC    cli/suffix.c
  CC    cli/commands.c
  CC    cli/gui.c
  CC    cli/progress.c
  CC    cli/main.c
  CC    cli/gas.c
  CC    cli/diag.c
  CC    cli/mfg.c
  CC    cli/argconfig.c
  CC    cli/fabric.c
  LD    switchtec
  CC    examples/temp.c
  LD    examples/temp
rm examples/temp.o
esdapps@esdapps-rome-2:~/error_msg/switchtec-user$
