### PR TITLE
Fix timestamp calculation in log parsing

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1125,6 +1125,13 @@ static int log_parse(int argc, char **argv)
 		{"MAILBOX", SWITCHTEC_LOG_PARSE_TYPE_MAILBOX, "mailbox log"},
 		{}
 	};
+	const struct argconfig_choice device_gen[] = {
+		{"GEN3", SWITCHTEC_GEN3, "GEN3"},
+		{"GEN4", SWITCHTEC_GEN4, "GEN4"},
+		{"GEN5", SWITCHTEC_GEN5, "GEN5"},
+		{"UNKNOWN", SWITCHTEC_GEN_UNKNOWN, "UNKNOWN"},
+		{}
+	};
 
 	static struct {
 		enum switchtec_log_parse_type log_type;
@@ -1134,11 +1141,13 @@ static int log_parse(int argc, char **argv)
 		const char *log_def_filename;
 		FILE *parsed_log_file;
 		const char *parsed_log_filename;
+		enum switchtec_gen gen;
 	} cfg = {
 		.log_type = SWITCHTEC_LOG_PARSE_TYPE_APP,
 		.bin_log_file = NULL,
 		.log_def_file = NULL,
 		.parsed_log_file = NULL,
+		.gen = SWITCHTEC_GEN_UNKNOWN
 	};
 	const struct argconfig_options opts[] = {
 		{"type", 't',
@@ -1147,6 +1156,14 @@ static int log_parse(int argc, char **argv)
 		 .argument_type = required_argument,
 		 .help = "log type to parse (default: APP)",
 		 .choices = log_types},
+		{"device_gen", 'g',
+		 .meta = "GEN", .cfg_type = CFG_CHOICES,
+		 .value_addr = &cfg.gen,
+		 .argument_type = required_argument,
+		 .help = "device generation (Only needed when parsing "
+			 "earlier log files which do not contain device "
+			 "generation information. Default: UNKNOWN)",
+		 .choices = device_gen},
 		{"log_input", .cfg_type = CFG_FILE_R,
 		 .value_addr = &cfg.bin_log_file,
 		 .argument_type = required_positional,
@@ -1167,7 +1184,7 @@ static int log_parse(int argc, char **argv)
 
 	ret = switchtec_parse_log(cfg.bin_log_file, cfg.log_def_file,
 				  cfg.parsed_log_file, cfg.log_type,
-				  &info);
+				  cfg.gen, &info);
 	if (ret < 0)
 		switchtec_perror("log_parse");
 	else
@@ -1182,6 +1199,17 @@ static int log_parse(int argc, char **argv)
 		fprintf(stderr, "Log def file:\t0x%08x\t0x%08x\n\n",
 			info.def_fw_version, info.def_sdk_version);
 		fprintf(stderr,	"The log file is parsed but the output file might contain errors.\n");
+	}
+
+	if (info.gen_unknown) {
+		fprintf(stderr, "\nWARNING: There is no device Generation information in the log file.\n");
+		fprintf(stderr, "           The log file is parsed but the output file contains errors.\n");
+		fprintf(stderr, "Hint: Use '-g' option to specify device generation.\n");
+	}
+
+	if (info.gen_ignored) {
+		fprintf(stderr, "\nNOTE: The input log file contains device generation information,\n");
+		fprintf(stderr, "        therefore the generation option in the command line is ignored.\n");
 	}
 
 	if (cfg.bin_log_file != NULL)

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -220,6 +220,8 @@ struct switchtec_log_file_info {
 	unsigned int def_sdk_version;
 	bool version_mismatch;
 	bool overflow;
+	bool gen_unknown;
+	bool gen_ignored;
 };
 
 /**
@@ -399,6 +401,7 @@ int switchtec_log_to_file(struct switchtec_dev *dev,
 int switchtec_parse_log(FILE *bin_log_file, FILE *log_def_file,
 			FILE *parsed_log_file,
 			enum switchtec_log_parse_type log_type,
+			enum switchtec_gen gen,
 			struct switchtec_log_file_info *info);
 int switchtec_log_def_to_file(struct switchtec_dev *dev,
 			      enum switchtec_log_def_type type,


### PR DESCRIPTION
Different generation of  device uses different factor to calculate timestamp value. The previous factor 10 is for Gen3 device, while Gen4/5 device uses factor 8.33.

In the case of offline parsing with `log-parse`, the device generation info may or may not be present in the log file header. We add option `-g` to allow user specify device generation, so that the timestamp can be parsed correctly. 

If the log file header already contains device generation info, then the `-g` option is ignored and a message is printed. 