### PR TITLE
platform/windows: set errno when MRPC command returns failure

### DIFF
--- a/lib/platform/windows.c
+++ b/lib/platform/windows.c
@@ -364,6 +364,8 @@ static int windows_cmd(struct switchtec_dev *dev, uint32_t cmd,
 		memcpy(resp, mres->data, resp_len);
 
 	ret = mres->status;
+	if (ret)
+		errno = ret;
 
 free_and_exit:
 	free(mres);


### PR DESCRIPTION
switchtec_cmd() is expected to set the errno to an MRPC code on
exit. However this was not done on the windows platform.

Thus MRPC errors returned zero instead of the appropriate error message.