### PR TITLE
Fix memory overflow of command 'status --help'

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -52,6 +52,7 @@ enum output_format {
 static const struct argconfig_choice output_fmt_choices[] = {
 	{"normal", FMT_NORMAL, "Human Readable Output"},
 	{"table",  FMT_TABLE,  "Tabular Output"},
+	{}
 };
 
 static const struct argconfig_choice bandwidth_types[] = {


### PR DESCRIPTION
The variable output_fmt_choices didn't end up with a NULL element as
boundary so that a memory overflow happened during the argument parsing.

This was only observed on an ARM system.