### PR TITLE
Fix 'mfg info' command in BL2 boot phase

### DIFF
--- a/cli/mfg.c
+++ b/cli/mfg.c
@@ -420,12 +420,6 @@ static int info(int argc, char **argv)
 
 	argconfig_parse(argc, argv, CMD_DESC_INFO, opts, &cfg, sizeof(cfg));
 
-	ret = switchtec_security_config_get(cfg.dev, &state);
-	if (ret) {
-		switchtec_perror("mfg info");
-		return ret;
-	}
-
 	phase_id = switchtec_boot_phase(cfg.dev);
 	printf("Current Boot Phase: \t\t\t%s\n", phase_id_to_string(phase_id));
 
@@ -446,6 +440,12 @@ static int info(int argc, char **argv)
 	if (phase_id == SWITCHTEC_BOOT_PHASE_BL2) {
 		printf("\nOther secure settings are only shown in the BL1 or Main Firmware phase.\n\n");
 		return 0;
+	}
+
+	ret = switchtec_security_config_get(cfg.dev, &state);
+	if (ret) {
+		switchtec_perror("mfg info");
+		return ret;
 	}
 
 	if (cfg.verbose)  {


### PR DESCRIPTION
Currently 'mfg info' will return 'Unknown MRPC command xxx' in BL2 boot phase. 

This is due to function `switchtec_security_config_get()` is not available in BL2. But the other functions required for 'mfg info' are still supported in BL2.

We change the call sequence so that boot phase, chip serial and security versions can be printed in BL2.