### PR TITLE
lib: Fix switchtec_security_config_set() fail issue

### DIFF
--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -687,7 +687,7 @@ static int security_config_set_gen5(struct switchtec_dev *dev,
 	uint32_t map_shift;
 	uint32_t map_mask;
 	int spi_clk;
-	uint8_t cmd_buf[64];
+	uint8_t cmd_buf[64]={};
 
 	ret = get_configs_gen5(dev, &reply);
 	if (ret)


### PR DESCRIPTION
The command buffer used was not initialized before use, so the subcommand field set to device is a random number.
Fixed by setting command buffer to 0.