### PR TITLE
Add 'ltssm-log' command to diag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install packages
-        run: sudo apt-get install gcc-multilib
+        run: sudo apt-get update; sudo apt-get install gcc-multilib
       - uses: actions/checkout@v2
       - name: configure
         run: ./configure

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -1158,6 +1158,12 @@ enum switchtec_diag_link {
 	SWITCHTEC_DIAG_LINK_PREVIOUS,
 };
 
+struct switchtec_diag_ltssm_log {
+	unsigned int timestamp;
+	float link_rate;
+	int link_state;
+};
+
 int switchtec_diag_cross_hair_enable(struct switchtec_dev *dev, int lane_id);
 int switchtec_diag_cross_hair_disable(struct switchtec_dev *dev);
 int switchtec_diag_cross_hair_get(struct switchtec_dev *dev, int start_lane_id,
@@ -1209,6 +1215,9 @@ int switchtec_diag_port_eq_tx_fslf(struct switchtec_dev *dev, int port_id,
 int switchtec_diag_perm_table(struct switchtec_dev *dev,
 			      struct switchtec_mrpc table[MRPC_MAX_ID]);
 int switchtec_diag_refclk_ctl(struct switchtec_dev *dev, int stack_id, bool en);
+int switchtec_diag_ltssm_log(struct switchtec_dev *dev,
+			     int port, int *log_count,
+			     struct switchtec_diag_ltssm_log *log_data);
 
 #ifdef __cplusplus
 }

--- a/lib/diag.c
+++ b/lib/diag.c
@@ -888,4 +888,126 @@ int switchtec_diag_refclk_ctl(struct switchtec_dev *dev, int stack_id, bool en)
 	return switchtec_cmd(dev, MRPC_REFCLK_S, &cmd, sizeof(cmd), NULL, 0);
 }
 
+/**
+ * @brief Get the LTSSM log of a port on a switchtec device
+ * @param[in]	dev    Switchtec device handle
+ * @param[in]	port   Switchtec Port
+ * @param[inout] log_count number of log entries
+ * @param[out] log    A pointer to an array containing the log
+ *
+ */
+int switchtec_diag_ltssm_log(struct switchtec_dev *dev,
+			     int port, int *log_count,
+			     struct switchtec_diag_ltssm_log *log_data)
+{
+	struct {
+		uint8_t sub_cmd;
+		uint8_t port;
+		uint8_t freeze;
+		uint8_t unused;
+	} ltssm_freeze;
+
+	struct {
+		uint8_t sub_cmd;
+		uint8_t port;
+	} status;
+	struct {
+		uint32_t w0_trigger_count;
+		uint32_t w1_trigger_count;
+		uint8_t log_num;
+	} status_output;
+
+	struct {
+		uint8_t sub_cmd;
+		uint8_t port;
+		uint8_t log_index;
+		uint8_t no_of_logs;
+	} log_dump;
+	struct {
+		uint32_t dw0;
+		uint32_t dw1;
+	} log_dump_out[256];
+
+	uint32_t dw1;
+	uint32_t dw0;
+	int major;
+	int minor;
+	int rate;
+	int ret;
+	int i;
+
+	/* freeze logs */
+	ltssm_freeze.sub_cmd = 14;
+	ltssm_freeze.port = port;
+	ltssm_freeze.freeze = 1;
+
+	ret = switchtec_cmd(dev, MRPC_DIAG_PORT_LTSSM_LOG, &ltssm_freeze,
+			    sizeof(ltssm_freeze), NULL, 0);
+	if (ret)
+		return ret;
+
+	/* get number of entries */
+	status.sub_cmd = 13;
+	status.port = port;
+	ret = switchtec_cmd(dev, MRPC_DIAG_PORT_LTSSM_LOG, &status,
+			    sizeof(status), &status_output,
+			    sizeof(status_output));
+	if (ret)
+		return ret;
+
+	if (status_output.log_num < *log_count)
+		*log_count = status_output.log_num;
+
+	/* get log data */
+	log_dump.sub_cmd = 15;
+	log_dump.port = port;
+	log_dump.log_index = 0;
+	log_dump.no_of_logs = *log_count;
+	if(log_dump.no_of_logs <= 126) {
+		ret = switchtec_cmd(dev, MRPC_DIAG_PORT_LTSSM_LOG, &log_dump,
+				    sizeof(log_dump), log_dump_out,
+				    8 * log_dump.no_of_logs);
+		if (ret)
+			return ret;
+	}
+	else {
+		log_dump.no_of_logs = 126;
+		ret = switchtec_cmd(dev, MRPC_DIAG_PORT_LTSSM_LOG, &log_dump,
+				    sizeof(log_dump), log_dump_out,
+				    8 * log_dump.no_of_logs);
+		if (ret)
+			return ret;
+
+		log_dump.log_index = 126;
+		log_dump.no_of_logs = log_dump.no_of_logs - 126;
+
+		ret = switchtec_cmd(dev, MRPC_DIAG_PORT_LTSSM_LOG, &log_dump,
+				    sizeof(log_dump), log_dump_out + 126,
+				    8 * log_dump.no_of_logs);
+		if (ret)
+			return ret;
+	}
+	for (i = 0; i < *log_count; i++) {
+		dw1 = log_dump_out[i].dw1;
+		dw0 = log_dump_out[i].dw0;
+		rate = (dw0 >> 13) & 0x3;
+		major = (dw0 >> 7) & 0xf;
+		minor = (dw0 >> 3) & 0xf;
+
+		log_data[i].timestamp = dw1 & 0x3ffffff;
+		log_data[i].link_rate = switchtec_gen_transfers[rate + 1];
+		log_data[i].link_state = major | (minor << 8);
+	}
+
+	/* unfreeze logs */
+	ltssm_freeze.sub_cmd = 14;
+	ltssm_freeze.port = port;
+	ltssm_freeze.freeze = 0;
+
+	ret = switchtec_cmd(dev, MRPC_DIAG_PORT_LTSSM_LOG, &ltssm_freeze,
+			    sizeof(ltssm_freeze), NULL, 0);
+
+	return ret;
+}
+
 /**@}*/


### PR DESCRIPTION
This is a revamp of PR #234: Pull Request to Integrate LTSSM Log MRPC into switchtec_user callable functions.

Sample output:
```
$ sudo ./switchtec diag ltssm-log 0 -p 32
LTSSM Log for Physical Port 32 (autowrap ON)

Idx     Delta Time      PCIe Rate       State
  0     000e55111       2.5G            Detect (QUIET)
  1     000002e5d       2.5G            Detect (ACTIVE0)
  2     000000003       2.5G            Detect (P0_TO_P1_0)
  3     000000000       2.5G            Detect (INACTIVE)
  4     000000000       2.5G            Polling (ACTIVE_ENTRY)
  5     000000ab5       2.5G            Polling (ACTIVE)
  6     000000040       2.5G            Polling (CFG)
  7     000000000       2.5G            Polling (INACTIVE)
  8     000000052       2.5G            Config (DS_LW_START)
  9     00000640c       2.5G            Config (US_LW_START)
 10     000000032       2.5G            Config (US_LW_ACCEPT)
 11     000000028       2.5G            Config (US_LN_WAIT)
 12     000000000       2.5G            Config (US_LN_ACCEPT)
 13     000000028       2.5G            Config (COMPLETE)
 14     000000022       2.5G            Config (IDLE)
 15     000000000       2.5G            Config (INACTIVE)
 16     000000000       2.5G            L0 (L0)
 17     000000000       2.5G            L0 (INACTIVE)
 18     000000032       2.5G            Recovery (RCVR_LOCK)
 19     000000055       2.5G            Recovery (RCVR_CFG)
 20     000000002       2.5G            Recovery (SPEED0)
 21     000000000       2.5G            Recovery (SPEED1)
...
```