### PR TITLE
Fix 'ltssm-log' issues

### DIFF
--- a/lib/diag.c
+++ b/lib/diag.c
@@ -969,8 +969,7 @@ int switchtec_diag_ltssm_log(struct switchtec_dev *dev,
 				    8 * log_dump.no_of_logs);
 		if (ret)
 			return ret;
-	}
-	else {
+	} else {
 		log_dump.no_of_logs = 126;
 		ret = switchtec_cmd(dev, MRPC_DIAG_PORT_LTSSM_LOG, &log_dump,
 				    sizeof(log_dump), log_dump_out,

--- a/lib/diag.c
+++ b/lib/diag.c
@@ -979,7 +979,7 @@ int switchtec_diag_ltssm_log(struct switchtec_dev *dev,
 			return ret;
 
 		log_dump.log_index = 126;
-		log_dump.no_of_logs = log_dump.no_of_logs - 126;
+		log_dump.no_of_logs = *log_count - 126;
 
 		ret = switchtec_cmd(dev, MRPC_DIAG_PORT_LTSSM_LOG, &log_dump,
 				    sizeof(log_dump), log_dump_out + 126,


### PR DESCRIPTION
Include the following changes:
- fix issues when the number of log entries is greater than 126: use `*log_count` to calculate the number of entries to read in the 2nd try
- fix indentation