### PR TITLE
Misc fixes for 'diag' commands

### DIFF
--- a/cli/diag.c
+++ b/cli/diag.c
@@ -1979,7 +1979,9 @@ static int refclk(int argc, char **argv)
 		int stack_id;
 		int enable;
 		int disable;
-	} cfg = {};
+	} cfg = {
+		.stack_id = -1
+	};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
 		{"disable", 'd', "", CFG_NONE, &cfg.disable, no_argument,
@@ -2000,6 +2002,11 @@ static int refclk(int argc, char **argv)
 
 	if (cfg.enable && cfg.disable) {
 		fprintf(stderr, "Must not set both --enable and --disable\n");
+		return -1;
+	}
+
+	if (cfg.stack_id == -1) {
+		fprintf(stderr, "Must specify stack ID using --stack or -s\n");
 		return -1;
 	}
 

--- a/cli/diag.c
+++ b/cli/diag.c
@@ -1994,12 +1994,12 @@ static int refclk(int argc, char **argv)
 			sizeof(cfg));
 
 	if (!cfg.enable && !cfg.disable) {
-		fprintf(stderr, "Must set either --enable or --disable");
+		fprintf(stderr, "Must set either --enable or --disable\n");
 		return -1;
 	}
 
 	if (cfg.enable && cfg.disable) {
-		fprintf(stderr, "Must not set both --enable and --disable");
+		fprintf(stderr, "Must not set both --enable and --disable\n");
 		return -1;
 	}
 

--- a/inc/switchtec/mrpc.h
+++ b/inc/switchtec/mrpc.h
@@ -116,7 +116,7 @@ enum mrpc_cmd {
 	MRPC_SECURITY_CONFIG_GET_GEN5 = 0x10C,
 	MRPC_SECURITY_CONFIG_SET_GEN5 = 0x10D,
 
-	MRPC_MAX_ID = 0x140,
+	MRPC_MAX_ID = 0x10E,
 };
 
 enum mrpc_bg_status {

--- a/lib/diag.c
+++ b/lib/diag.c
@@ -862,7 +862,7 @@ int switchtec_diag_rcvr_ext(struct switchtec_dev *dev, int port_id,
 int switchtec_diag_perm_table(struct switchtec_dev *dev,
 			      struct switchtec_mrpc table[MRPC_MAX_ID])
 {
-	uint32_t perms[MRPC_MAX_ID / 32];
+	uint32_t perms[(MRPC_MAX_ID + 31) / 32];
 	int i, ret;
 
 	ret = switchtec_cmd(dev, MRPC_MRPC_PERM_TABLE_GET, NULL, 0,

--- a/lib/diag.c
+++ b/lib/diag.c
@@ -192,6 +192,8 @@ int switchtec_diag_eye_start(struct switchtec_dev *dev, int lane_mask[4],
 			     struct range *x_range, struct range *y_range,
 			     int step_interval)
 {
+	int err;
+	int ret;
 	struct switchtec_diag_port_eye_start in = {
 		.sub_cmd = MRPC_EYE_OBSERVE_START,
 		.lane_mask[0] = lane_mask[0],
@@ -207,7 +209,14 @@ int switchtec_diag_eye_start(struct switchtec_dev *dev, int lane_mask[4],
 		.step_interval = step_interval,
 	};
 
-	return switchtec_diag_eye_cmd(dev, &in, sizeof(in));
+	ret = switchtec_diag_eye_cmd(dev, &in, sizeof(in));
+
+	/* Add delay so hardware has enough time to start */
+	err = errno;
+	usleep(200000);
+	errno = err;
+
+	return ret;
 }
 
 static uint64_t hi_lo_to_uint64(uint32_t lo, uint32_t hi)
@@ -296,11 +305,20 @@ retry:
  */
 int switchtec_diag_eye_cancel(struct switchtec_dev *dev)
 {
+	int ret;
+	int err;
 	struct switchtec_diag_port_eye_cmd in = {
 		.sub_cmd = MRPC_EYE_OBSERVE_CANCEL,
 	};
 
-	return switchtec_diag_eye_cmd(dev, &in, sizeof(in));
+	ret = switchtec_diag_eye_cmd(dev, &in, sizeof(in));
+
+	/* Add delay so hardware can stop completely */
+	err = errno;
+	usleep(200000);
+	errno = err;
+
+	return ret;
 }
 
 /**


### PR DESCRIPTION
This PR adds the following fixes:
- add missing '\n' in error messages
- make _stack_ parameter mandatory in `refclk` command 
- add delay to eye diagram start/cancel command: hardware needs some time to complete the start/cancel operation. The ideal solution would be to check hardware state and return after the state has changed to STARTED/STOPPED. Unfortunately, hardware does not provide a 'check state' command, so we can only add a long enough delay before returning.