### PR TITLE
cli: Fix 'diag refclk' stack 0 checking

### DIFF
--- a/cli/diag.c
+++ b/cli/diag.c
@@ -1988,7 +1988,7 @@ static int refclk(int argc, char **argv)
 		 "disable the rfclk output"},
 		{"enable", 'e', "", CFG_NONE, &cfg.enable, no_argument,
 		 "enable the rfclk output"},
-		{"stack", 's', "NUM", CFG_POSITIVE, &cfg.stack_id,
+		{"stack", 's', "NUM", CFG_NONNEGATIVE, &cfg.stack_id,
 		required_argument, "stack to operate on"},
 		{NULL}};
 


### PR DESCRIPTION
Stack 0 is a valid input for 'diag refclk' command