### PR TITLE
cli: Fix format security warning

### DIFF
--- a/cli/graph.c
+++ b/cli/graph.c
@@ -134,7 +134,7 @@ static void draw_status(WINDOW *win, int x_off, int x_cnt, const char *status)
 	mvwprintw(win, 0, 0, "     ");
 	for (i = 0; i < x_cnt * 2 + x_off; i++)
 		mvwaddch(win, 1, i, ' ');
-	mvwprintw(win, 1, x_off, status);
+	mvwprintw(win, 1, x_off, "%s", status);
 	wrefresh(win);
 }
 


### PR DESCRIPTION
Make the format string explicit to fix a format security warning:

```
gcc -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -g -Wall -Wno-initializer-overrides -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fPIC -I. -Iinc -Ibuild -DCOMPLETE_ENV=\"SWITCHTEC_COMPLETE\"  -c -MT build/cli/graph.o -MMD -MP -MF build/cli/graph.d cli/graph.c -o build/cli/graph.o
cli/graph.c: In function 'draw_status':
cli/graph.c:137:9: error: format not a string literal and no format arguments [-Werror=format-security]
  137 |         mvwprintw(win, 1, x_off, status);
      |         ^~~~~~~~~
```