### PR TITLE
build: Don't strip binary by default

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -149,7 +149,7 @@ install-bin: compile
 	$(Q)install -d $(BINDIR) $(LIBDIR)
 
 	@$(NQ) echo "  INSTALL  $(BINDIR)/$(INSTEXENAME)"
-	$(Q)install -s $(EXENAME) $(BINDIR)/$(INSTEXENAME)
+	$(Q)install $(EXENAME) $(BINDIR)/$(INSTEXENAME)
 	@$(NQ) echo "  INSTALL  $(LIBDIR)/$(STLIBNAME)"
 	$(Q)install -m 0664 $(STLIBNAME) $(LIBDIR)
 	@$(NQ) echo "  INSTALL  $(LIBDIR)/$(IMPLIBNAME).$(VERSION)"


### PR DESCRIPTION
Our meta build system doesn't like that the binary is pre-stripped prior to consumption. We should avoid stripping and let the user strip the binary if needed.

If you have any opinions about making this a flag, that is fine with me.