### PR TITLE
Fixes related to the max number of ports

### DIFF
--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -441,6 +441,15 @@ static inline int switchtec_is_gen5(struct switchtec_dev *dev)
 }
 
 /**
+ * @brief Return the max number of ports of a Switchtec device.
+ */
+static inline int switchtec_max_supported_ports(struct switchtec_dev *dev)
+{
+	return switchtec_is_gen5(dev) ? SWITCHTEC_MAX_PORTS :
+	       switchtec_is_gen4(dev) ? 52 : 48;
+}
+
+/**
  * @brief Return whether a Switchtec device is PFX.
  */
 static inline int switchtec_is_pfx(struct switchtec_dev *dev)

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -549,7 +549,7 @@ int switchtec_status(struct switchtec_dev *dev,
 		s[p].link_up = ports[i].linkup_linkrate >> 7;
 		s[p].link_rate = ports[i].linkup_linkrate & 0x7F;
 		s[p].ltssm = le16toh(ports[i].LTSSM);
-		s[p].ltssm_str = switchtec_ltssm_str(s[i].ltssm, 1);
+		s[p].ltssm_str = switchtec_ltssm_str(s[p].ltssm, 1);
 		s[p].lane_reversal = ports[i].lane_reversal;
 		s[p].lane_reversal_str = lane_reversal_str(s[p].link_up,
 							   s[p].lane_reversal);

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -498,10 +498,7 @@ int switchtec_status(struct switchtec_dev *dev,
 		return -errno;
 	}
 
-	if (switchtec_is_gen5(dev))
-		max_ports = 60;
-	else
-		max_ports = 52;
+	max_ports = switchtec_max_supported_ports(dev);
 
 	struct {
 		uint8_t phys_port_id;


### PR DESCRIPTION
We were running into the same memory corruption issues as seen in #317 because we're in the process of upgrading from an older version of `switchtec`. These were not gen4 or gen5 devices and so various places that used `SWITCHTEC_MAX_PORTS` would go out of bounds when accessing arrays.

I attempted to fix this by correcting the logic in a helper function ~and removing some places where there was a risk of going out of bounds. I did not remove all uses of `SWITCHTEC_MAX_PORTS` since most appeared to be safe (i.e. used to initialize arrays but bounds were checked properly). I'm not super knowledgeable about this tool so maybe a maintainer can verify if the other places need to be fixed...~

Fixes #317 