### PR TITLE
Fix BDF search by matching a single character for function

### DIFF
--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -419,7 +419,7 @@ static void get_port_bdf(const char *searchpath, int port,
 	glob_t paths;
 	int ret;
 
-	ret = snprintf(syspath, sizeof(syspath), "%s/*:*:%02x.*",
+	ret = snprintf(syspath, sizeof(syspath), "%s/*:*:%02x.?",
 		       searchpath, port);
 	if (ret >= sizeof(syspath))
 		return;


### PR DESCRIPTION
The first device underneath a switch does not obtain all its `status` information because the glob search matches more than one entry (line 429).  For example:
```
$ ls -l /sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/
total 0
drwxr-xr-x  3 root root    0 Oct  3 21:59 0000:01:00.0:pcie102  <-----
drwxr-xr-x 12 root root    0 Oct  3 21:59 0000:02:00.0
drwxr-xr-x 12 root root    0 Oct  3 21:59 0000:02:01.0
drwxr-xr-x 12 root root    0 Oct  3 21:59 0000:02:02.0
drwxr-xr-x 12 root root    0 Oct  3 21:59 0000:02:03.0
drwxr-xr-x 10 root root    0 Oct  3 21:59 0000:02:04.0
drwxr-xr-x 11 root root    0 Oct  3 21:59 0000:02:05.0
```

The glob search will return both `0000:01:00.0:pcie102` and `0000:02:00.0` therefore `pci_bdf` for the device is not populated (see line 430).