### PR TITLE
lib: Fallback on EBADMSG error code

### DIFF
--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -1755,7 +1755,7 @@ int switchtec_get_device_info(struct switchtec_dev *dev,
 			*rev = (dev_info >> 8) & 0x0f;
 		if (gen)
 			*gen = map_to_gen((dev_info >> 12) & 0x0f);
-	} else if (ERRNO_MRPC(errno) == ERR_CMD_INVALID) {
+	} else if (errno == EBADMSG || ERRNO_MRPC(errno) == ERR_CMD_INVALID) {
 		if (phase)
 			*phase = SWITCHTEC_BOOT_PHASE_FW;
 		if (gen)


### PR DESCRIPTION
Some GEN3 hardware ends up responding to MRPC_I2C_TWI_PING with a bad status code and the kernel translates into an EBADMSG error code. When this happens, the code should fall back into the GEN3 path.

Resolves: #323 ("info command returning 'Bad message'")