### PR TITLE
Ensure entire switchtec_event_summary struct is set

### DIFF
--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -829,6 +829,9 @@ static void event_summary_copy(struct switchtec_event_summary *dst,
 
 	for (i = 0; i < SWITCHTEC_MAX_PFF_CSR && i < size; i++)
 		dst->pff[i] = src->pff[i];
+
+	for (; i < SWITCHTEC_MAX_PFF_CSR; i++)
+		dst->pff[i] = 0;
 }
 
 #define EV(t, n)[SWITCHTEC_ ## t ## _EVT_ ## n] = \


### PR DESCRIPTION
In normal cases, event_summary_copy() will set the entire switchtec_event_summary struct. However, if the library falls back to the smaller SWITCHTEC_IOCTL_EVENT_SUMMARY_LEGACY, then a size less than SWITCHTEC_MAX_PFF_CSR will be passed to the function and a portion of the function will be left unset.

There are a number of places in the code where this function gets called pointing to an unitialized structure on the stack. So fix this issue by ensuring event_summary_copy() sets the entire structure.

Resolves: #325 ("events command returning 'Invalid argument'")