### PR TITLE
Info

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -189,6 +189,7 @@ static int print_dev_info(struct switchtec_dev *dev)
 	int ret;
 	int device_id;
 	char version[64];
+	enum switchtec_boot_phase phase;
 	enum switchtec_rev hw_rev;
 
 	device_id = switchtec_device_id(dev);
@@ -197,17 +198,22 @@ static int print_dev_info(struct switchtec_dev *dev)
 	if (ret < 0)
 		strcpy(version, "N/A");
 
-	ret = switchtec_get_device_info(dev, NULL, NULL, &hw_rev);
+	ret = switchtec_get_device_info(dev, &phase, NULL, &hw_rev);
 	if (ret) {
 		switchtec_perror("dev info");
 		return ret;
 	}
 
-	printf("%s:\n", switchtec_name(dev));
+	printf("%s (%s):\n", switchtec_name(dev),
+	       switchtec_phase_id_str(phase));
 	printf("    Generation:  %s\n", switchtec_gen_str(dev));
 	printf("    HW Revision: %s\n", switchtec_rev_str(hw_rev));
-	printf("    Variant:     %s\n", switchtec_variant_str(dev));
-	printf("    Device ID:   0x%04x\n", device_id);
+	printf("    Variant:     %s\n",
+	       device_id ? switchtec_variant_str(dev) : "N/A");
+	if (device_id)
+		printf("    Device ID:   0x%04x\n", device_id);
+	else
+		printf("    Device ID:   %s\n", "N/A");
 	printf("    FW Version:  %s\n", version);
 
 	return 0;

--- a/cli/main.c
+++ b/cli/main.c
@@ -194,10 +194,8 @@ static int print_dev_info(struct switchtec_dev *dev)
 	device_id = switchtec_device_id(dev);
 
 	ret = switchtec_get_fw_version(dev, version, sizeof(version));
-	if (ret < 0) {
-		switchtec_perror("dev info");
-		return ret;
-	}
+	if (ret < 0)
+		strcpy(version, "N/A");
 
 	ret = switchtec_get_device_info(dev, NULL, NULL, &hw_rev);
 	if (ret) {

--- a/cli/mfg.c
+++ b/cli/mfg.c
@@ -64,20 +64,6 @@ static const struct argconfig_choice secure_state_choices[] = {
 	{}
 };
 
-static const char* phase_id_to_string(enum switchtec_boot_phase phase_id)
-{
-	switch(phase_id) {
-	case SWITCHTEC_BOOT_PHASE_BL1:
-		return "BL1";
-	case SWITCHTEC_BOOT_PHASE_BL2:
-		return "BL2";
-	case SWITCHTEC_BOOT_PHASE_FW:
-		return "Main Firmware";
-	default:
-		return "Unknown Phase";
-	}
-}
-
 #define CMD_DESC_PING "ping device and get current boot phase"
 
 static int ping(int argc, char **argv)
@@ -282,7 +268,8 @@ static int info(int argc, char **argv)
 	}
 
 	phase_id = switchtec_boot_phase(cfg.dev);
-	printf("Current Boot Phase: \t\t\t%s\n", phase_id_to_string(phase_id));
+	printf("Current Boot Phase: \t\t\t%s\n",
+	       switchtec_phase_id_str(phase_id));
 
 	ret = switchtec_sn_ver_get(cfg.dev, &sn_info);
 	if (ret) {

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -610,6 +610,24 @@ static inline const char *switchtec_variant_str(struct switchtec_dev *dev)
 	return str;
 }
 
+/**
+ * @brief Return the phase string for a phase id.
+ */
+static inline const char* switchtec_phase_id_str(
+		enum switchtec_boot_phase phase_id)
+{
+	switch(phase_id) {
+	case SWITCHTEC_BOOT_PHASE_BL1:
+		return "BL1";
+	case SWITCHTEC_BOOT_PHASE_BL2:
+		return "BL2";
+	case SWITCHTEC_BOOT_PHASE_FW:
+		return "Main Firmware";
+	default:
+		return "Unknown Phase";
+	}
+}
+
 /** @brief Number of GT/s capable for each PCI generation or \p link_rate */
 static const float switchtec_gen_transfers[] = {0, 2.5, 5, 8, 16, 32};
 /** @brief Number of GB/s capable for each PCI generation or \p link_rate */

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -835,6 +835,8 @@ int switchtec_fw_read(struct switchtec_dev *dev, unsigned long addr,
 		      size_t len, void *buf);
 void switchtec_fw_perror(const char *s, int ret);
 int switchtec_fw_file_info(int fd, struct switchtec_fw_image_info *info);
+int switchtec_get_device_id_bl2(struct switchtec_dev *dev,
+				unsigned short *device_id);
 int switchtec_fw_file_secure_version_newer(struct switchtec_dev *dev,
 					   int img_fd);
 const char *switchtec_fw_image_type(const struct switchtec_fw_image_info *info);

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -1097,6 +1097,27 @@ static int switchtec_fw_part_info(struct switchtec_dev *dev, int nr_info,
 	return nr_info;
 }
 
+int switchtec_get_device_id_bl2(struct switchtec_dev *dev,
+			        unsigned short *device_id)
+{
+	int ret;
+	uint8_t subcmd = MRPC_PART_INFO_GET_ALL_INFO;
+	struct switchtec_flash_info_gen4 all_info;
+
+	if (dev->gen != SWITCHTEC_GEN_UNKNOWN)
+		return -EINVAL;
+
+	ret = switchtec_cmd(dev, MRPC_PART_INFO, &subcmd,
+			    sizeof(subcmd), &all_info,
+			    sizeof(all_info));
+	if (ret)
+		return ret;
+
+	*device_id = le16toh(all_info.device_id);
+
+	return 0;
+}
+
 static long multicfg_subcmd(struct switchtec_dev *dev, uint32_t subcmd,
 			    uint8_t index)
 {

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -192,7 +192,7 @@ static int set_gen_variant(struct switchtec_dev * dev)
 			dev->gen = id->gen;
 			dev->var = id->var;
 
-			return 0;
+			break;
 		}
 
 		id++;

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -186,6 +186,9 @@ static int set_gen_variant(struct switchtec_dev * dev)
 	dev->gen = SWITCHTEC_GEN_UNKNOWN;
 	dev->var = SWITCHTEC_VAR_UNKNOWN;
 	dev->device_id = dev->ops->get_device_id(dev);
+	if (!dev->device_id)
+		switchtec_get_device_id_bl2(dev,
+					    (unsigned short *)&dev->device_id);
 
 	while (id->device_id) {
 		if (id->device_id == dev->device_id) {


### PR DESCRIPTION
Generally two fixes in this PR.

1. In BL2 boot phase, use MRPC instead of GAS access to retrieve device id, to make command info be capable to report them correctly.
2. Make command info's output more reasonable in BL1 boot phase by showing the boot phase in all boot phases and 'N/A' for unavailable information in BL1. 

The updated output looks like below.
```
# sudo ./switchtec info /dev/i2c-5:0x58
/dev/i2c-5:0x58 (BL1):
    Generation:  GEN4
    HW Revision: REVB
    Variant:     N/A
    Device ID:   N/A
    FW Version:  N/A

# sudo ./switchtec mfg boot-resume /dev/i2c-5:0x58
WARNING: if your system does not support hotplug,
your device might not be immediately accessible
after a normal boot process. In this case, be sure
to reboot your system after sending this command.

Do you want to continue? [y/N] y

# sudo ./switchtec info /dev/i2c-5:0x58
/dev/i2c-5:0x58 (BL2):
    Generation:  GEN4
    HW Revision: REVB
    Variant:     PSX
    Device ID:   0x4100
    FW Version:  3.90 B059
```