### PR TITLE
cli/progress: Fix int overflow with progress bar

### DIFF
--- a/cli/progress.c
+++ b/cli/progress.c
@@ -77,7 +77,7 @@ static void timeval_subtract(struct timeval *result,
 
 static void print_bar(int cur, int total)
 {
-	int bar_width;
+	long long bar_width;
 	int i;
 	float progress = cur * 100.0 / total;
 	int pos;


### PR DESCRIPTION
If an image size of 40MB is passed in an integer overflow occurs (assuming a terminal width >100) because the current is multipled by the bar width (40MB * 100 > 32-bit signed int). Casting this to a long long fixes the issue.