### PR TITLE
Add image string information to the display output of the fw-info subcommand

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1770,17 +1770,37 @@ static const char *fw_active_string(struct switchtec_fw_image_info *inf)
 	return inf->active ? " - Active" : "";
 }
 
+static void char_arr_print(char *buf, size_t len)
+{
+    int i;
+
+    for (i = 0; i < len; i++)
+    {
+        printf("%c", buf[i]);
+        if (buf[i] == 0)
+        {
+            break;
+        }
+    }
+}
+
 static void print_fw_part_line(const char *tag,
 			       struct switchtec_fw_image_info *inf)
 {
 	if (!inf)
 		return;
 
-	printf("  %-4s\tVersion: %-8s\tCRC: %08lx\t%4s%11s%s\n",
+	printf("  %-4s\tVersion: %-8s\tCRC: %08lx\t%4s%11s%s ",
 	       tag, inf->version, inf->image_crc,
 	       inf->read_only ? "(RO)" : "",
 	       inf->running ? "  (Running)" : "",
 	       inf->valid ? "" : "  (Invalid)");
+
+	if(inf->valid){
+	    printf("Image String:");
+	    char_arr_print(inf->img_str, sizeof(inf->img_str));
+	}
+	printf("\n");
 }
 
 static int print_fw_part_info(struct switchtec_dev *dev)

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -259,6 +259,7 @@ struct switchtec_fw_image_info {
 	size_t part_body_offset;		//!< Partition image body offset
 	size_t image_len;			//!< Length of the image
 	unsigned long image_crc;		//!< CRC checksum of the image
+	char img_str[16];
 
 	bool valid;
 	bool active;

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -1067,6 +1067,7 @@ static int switchtec_fw_info_metadata_gen5(struct switchtec_dev *dev,
 		.part_id = inf->part_id,
 	};
 	int ret;
+	int i;
 
 	if (inf->part_id == SWITCHTEC_FW_PART_ID_G5_NVLOG)
 		return 1;
@@ -1094,6 +1095,9 @@ static int switchtec_fw_info_metadata_gen5(struct switchtec_dev *dev,
 	inf->image_crc = le32toh(metadata->image_crc);
 	inf->image_len = le32toh(metadata->image_len);
 	inf->metadata = metadata;
+
+	for(i = 0; i< 16; i++)
+            inf->img_str[i] = metadata->img_str[i];
 
 	return 0;
 


### PR DESCRIPTION
Add image string information to the display output of the fw-info subcommand. The user can modify the image string in the firmware header using the ChipLink Firmware Image Header Editor tool. After updating the firmware, use Switchtec-User fw-info to verify the image string information.