### PR TITLE
Added minor fixes to memory management

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -188,7 +188,7 @@ static int print_dev_info(struct switchtec_dev *dev)
 {
 	int ret;
 	int device_id;
-	char version[64];
+	char version[32];
 	enum switchtec_boot_phase phase;
 	enum switchtec_rev hw_rev;
 

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -1601,6 +1601,7 @@ switchtec_fw_part_summary(struct switchtec_dev *dev)
 		break;
 	default:
 		errno = EINVAL;
+		free(summary);
 		return NULL;
 	}
 


### PR DESCRIPTION
- First change in lib/fw.c relates to the summary pointer not being freed after returning from the default case in the switch statement Added a call to free the summary pointer before returning.

- Second change in cli/main.c changed the 64 byte buffer sent to switchtec_get_fw_version function to 32. Since we are expecting the version information to be at most 32 bytes there is no need to have the destination buffer set to 64 when strncpy is called in the switchtec_get_fw_version function within lib/platform/platform.c.