### PR TITLE
add minor version to info command

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -191,6 +191,9 @@ static int print_dev_info(struct switchtec_dev *dev)
 	char version[32];
 	enum switchtec_boot_phase phase;
 	enum switchtec_rev hw_rev;
+	char minor_str[8] = "";
+	int dev_ver;
+	int minor_ver;
 
 	device_id = switchtec_device_id(dev);
 
@@ -203,11 +206,20 @@ static int print_dev_info(struct switchtec_dev *dev)
 		switchtec_perror("dev info");
 		return ret;
 	}
+	if (switchtec_is_gen5(dev)) {
+		switchtec_get_device_version(dev, &dev_ver);
+		if (ret) {
+			switchtec_perror("dev version");
+			return ret;
+		}
+		minor_ver = ((dev_ver >> 0x10) & 0xFF);
+		sprintf(minor_str, ".%d", minor_ver);
+	}
 
 	printf("%s (%s):\n", switchtec_name(dev),
 	       switchtec_phase_id_str(phase));
 	printf("    Generation:  %s\n", switchtec_gen_str(dev));
-	printf("    HW Revision: %s\n", switchtec_rev_str(hw_rev));
+	printf("    HW Revision: %s%s\n", switchtec_rev_str(hw_rev), minor_str);
 	printf("    Variant:     %s\n",
 	       device_id ? switchtec_variant_str(dev) : "N/A");
 	if (device_id)

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -358,6 +358,7 @@ int switchtec_list(struct switchtec_device_info **devlist);
 void switchtec_list_free(struct switchtec_device_info *devlist);
 int switchtec_get_fw_version(struct switchtec_dev *dev, char *buf,
 			     size_t buflen);
+int switchtec_get_device_version(struct switchtec_dev *dev, int *res);
 int switchtec_cmd(struct switchtec_dev *dev, uint32_t cmd,
 		  const void *payload, size_t payload_len, void *resp,
 		  size_t resp_len);

--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -188,6 +188,15 @@ int gasop_get_fw_version(struct switchtec_dev *dev, char *buf,
 	return 0;
 }
 
+int gasop_get_device_version(struct switchtec_dev *dev, int *res)
+{
+	uint32_t dev_ver;
+	dev_ver = gas_reg_read32(dev, sys_info.device_version);
+
+	*res = dev_ver;
+	return 0;
+}
+
 int gasop_pff_to_port(struct switchtec_dev *dev, int pff,
 		      int *partition, int *port)
 {

--- a/lib/platform/gasops.h
+++ b/lib/platform/gasops.h
@@ -36,6 +36,7 @@ int gasop_cmd(struct switchtec_dev *dev, uint32_t cmd,
 int gasop_get_device_id(struct switchtec_dev *dev);
 int gasop_get_fw_version(struct switchtec_dev *dev, char *buf,
 			 size_t buflen);
+int gasop_get_device_version(struct switchtec_dev *dev, int *res);
 int gasop_pff_to_port(struct switchtec_dev *dev, int pff,
 		      int *partition, int *port);
 int gasop_port_to_pff(struct switchtec_dev *dev, int partition,

--- a/lib/platform/linux-eth.c
+++ b/lib/platform/linux-eth.c
@@ -524,6 +524,7 @@ static const struct switchtec_ops eth_ops = {
 	.cmd = eth_cmd,
 	.get_device_id = gasop_get_device_id,
 	.get_fw_version = gasop_get_fw_version,
+	.get_device_version = gasop_get_device_version,
 	.pff_to_port = gasop_pff_to_port,
 	.port_to_pff = gasop_port_to_pff,
 	.flash_part = gasop_flash_part,

--- a/lib/platform/linux-i2c.c
+++ b/lib/platform/linux-i2c.c
@@ -623,6 +623,7 @@ static const struct switchtec_ops i2c_ops = {
 	.cmd = gasop_cmd,
 	.get_device_id = gasop_get_device_id,
 	.get_fw_version = gasop_get_fw_version,
+	.get_device_version = gasop_get_device_version,
 	.pff_to_port = gasop_pff_to_port,
 	.port_to_pff = gasop_port_to_pff,
 	.flash_part = gasop_flash_part,

--- a/lib/platform/linux-uart.c
+++ b/lib/platform/linux-uart.c
@@ -439,6 +439,7 @@ static const struct switchtec_ops uart_ops = {
 	.cmd = gasop_cmd,
 	.get_device_id = gasop_get_device_id,
 	.get_fw_version = gasop_get_fw_version,
+	.get_device_version = gasop_get_device_version,
 	.pff_to_port = gasop_pff_to_port,
 	.port_to_pff = gasop_port_to_pff,
 	.flash_part = gasop_flash_part,

--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -300,6 +300,26 @@ static int linux_get_fw_version(struct switchtec_dev *dev, char *buf,
 	return 0;
 }
 
+static int linux_get_device_version(struct switchtec_dev *dev, int *version_res)
+{
+	int ret;
+	int version;
+	char syspath[PATH_MAX];
+	struct switchtec_linux *ldev = to_switchtec_linux(dev);
+
+	ret = dev_to_sysfs_path(ldev, "device_version", syspath, sizeof(syspath));
+	if (ret)
+		return ret;
+
+	version = sysfs_read_int(syspath, 16);
+	if (version < 0)
+		return version;
+	
+	memcpy(version_res, &version, sizeof(int));
+
+	return 0;
+}
+
 static int submit_cmd(struct switchtec_linux *ldev, uint32_t cmd,
 		      const void *payload, size_t payload_len)
 {
@@ -971,6 +991,7 @@ static const struct switchtec_ops linux_ops = {
 	.close = linux_close,
 	.get_device_id = linux_get_device_id,
 	.get_fw_version = linux_get_fw_version,
+	.get_device_version = linux_get_device_version,
 	.cmd = linux_cmd,
 	.get_devices = linux_get_devices,
 	.pff_to_port = linux_pff_to_port,

--- a/lib/platform/platform.c
+++ b/lib/platform/platform.c
@@ -151,6 +151,20 @@ int switchtec_get_fw_version(struct switchtec_dev *dev, char *buf,
 }
 
 /**
+ * @brief Get the minor version number as a user readable int
+ * @ingroup Device
+ * @param[in] dev	Switchtec device handle
+ * @param[in] res	Int to put the version in
+ */
+int switchtec_get_device_version(struct switchtec_dev *dev, int *res)
+{
+	if (!dev->ops->get_device_version)
+		return 0;
+
+	return dev->ops->get_device_version(dev, res);
+}
+
+/**
  * @brief Execute an MRPC command
  * @ingroup Device
  * @param[in]  dev		Switchtec device handle

--- a/lib/platform/windows.c
+++ b/lib/platform/windows.c
@@ -432,6 +432,7 @@ static const struct switchtec_ops windows_ops = {
 
 	.get_device_id = gasop_get_device_id,
 	.get_fw_version = gasop_get_fw_version,
+	.get_device_version = gasop_get_device_version,
 	.pff_to_port = gasop_pff_to_port,
 	.port_to_pff = gasop_port_to_pff,
 	.flash_part = gasop_flash_part,

--- a/lib/switchtec_priv.h
+++ b/lib/switchtec_priv.h
@@ -93,6 +93,7 @@ struct switchtec_ops {
 	int (*get_device_id)(struct switchtec_dev *dev);
 	int (*get_fw_version)(struct switchtec_dev *dev, char *buf,
 			      size_t buflen);
+	int (*get_device_version)(struct switchtec_dev *dev, int *device_version);
 	int (*cmd)(struct switchtec_dev *dev,  uint32_t cmd,
 		   const void *payload, size_t payload_len, void *resp,
 		   size_t resp_len);


### PR DESCRIPTION
Added the minor version number to the info command through reading the GAS address for Firmware Version. Add additional version info to the HW Revision section.