### PR TITLE
Add toggle option for riotcore gen5

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1799,6 +1799,8 @@ static int print_fw_part_info(struct switchtec_dev *dev)
 	print_fw_part_line("BOOT", sum->boot.active);
 	print_fw_part_line("MAP", sum->map.active);
 	print_fw_part_line("KEY", sum->key.active);
+	if (switchtec_is_gen5(dev))
+		print_fw_part_line("RIOT", sum->riot.active);
 	print_fw_part_line("BL2", sum->bl2.active);
 	print_fw_part_line("IMG", sum->img.active);
 	print_fw_part_line("CFG", sum->cfg.active);
@@ -1809,6 +1811,8 @@ static int print_fw_part_info(struct switchtec_dev *dev)
 	printf("Inactive Partitions:\n");
 	print_fw_part_line("MAP", sum->map.inactive);
 	print_fw_part_line("KEY", sum->key.inactive);
+	if (switchtec_is_gen5(dev))
+		print_fw_part_line("RIOT", sum->riot.inactive);
 	print_fw_part_line("BL2", sum->bl2.inactive);
 	print_fw_part_line("IMG", sum->img.inactive);
 	print_fw_part_line("CFG", sum->cfg.inactive);
@@ -2019,6 +2023,7 @@ static int fw_toggle(int argc, char **argv)
 		int key;
 		int firmware;
 		int config;
+		int riotcore;
 	} cfg = {};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
@@ -2030,23 +2035,29 @@ static int fw_toggle(int argc, char **argv)
 		 "toggle IMG firmware"},
 		{"config", 'c', "", CFG_NONE, &cfg.config, no_argument,
 		 "toggle CFG data"},
+		{"riotcore", 'r', "", CFG_NONE, &cfg.riotcore, no_argument,
+		 "toggle RIOTCORE - Gen5 switch only"},
 		{NULL}};
 
 	argconfig_parse(argc, argv, CMD_DESC_FW_TOGGLE, opts, &cfg, sizeof(cfg));
 
-	if (!cfg.bl2 && !cfg.key && !cfg.firmware && !cfg.config) {
+	if (!cfg.bl2 && !cfg.key && !cfg.firmware && !cfg.config && !cfg.riotcore) {
 		fprintf(stderr, "NOTE: Not toggling images as no "
 			"partition type options were specified\n\n");
-	} else if ((cfg.bl2 || cfg.key) && switchtec_is_gen3(cfg.dev)) {
-		fprintf(stderr, "Firmware type BL2 and Key manifest"
+	} else if ((cfg.bl2 || cfg.key || cfg.riotcore) && switchtec_is_gen3(cfg.dev)) {
+		fprintf(stderr, "Firmware type BL2, Key manifest, or RIORCORE "
 			"are not supported by Gen3 switches\n");
+		return 1;
+	} else if (cfg.riotcore && switchtec_is_gen4(cfg.dev)){
+		fprintf(stderr, "Firmware type RIOTCORE is not supported by Gen4 switchtes\n");
 		return 1;
 	} else {
 		ret = switchtec_fw_toggle_active_partition(cfg.dev,
 							   cfg.bl2,
 							   cfg.key,
 							   cfg.firmware,
-							   cfg.config);
+							   cfg.config,
+							   cfg.riotcore);
 		if (ret)
 			err = errno;
 	}

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -843,7 +843,8 @@ enum switchtec_fw_ro {
 
 int switchtec_fw_toggle_active_partition(struct switchtec_dev *dev,
 					 int toggle_bl2, int toggle_key,
-					 int toggle_fw, int toggle_cfg);
+					 int toggle_fw, int toggle_cfg,
+					 int toggle_riotcore);
 int switchtec_fw_write_fd(struct switchtec_dev *dev, int img_fd,
 			  int dont_activate, int force,
 			  void (*progress_callback)(int cur, int tot));

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -247,15 +247,18 @@ static int switchtec_fw_wait(struct switchtec_dev *dev,
  */
 int switchtec_fw_toggle_active_partition(struct switchtec_dev *dev,
 					 int toggle_bl2, int toggle_key,
-					 int toggle_fw, int toggle_cfg)
+					 int toggle_fw, int toggle_cfg,
+					 int toggle_riotcore)
 {
 	uint32_t cmd_id;
+	size_t cmd_size;
 	struct {
 		uint8_t subcmd;
 		uint8_t toggle_fw;
 		uint8_t toggle_cfg;
 		uint8_t toggle_bl2;
 		uint8_t toggle_key;
+		uint8_t toggle_riotcore;
 	} cmd;
 
 	if (switchtec_boot_phase(dev) == SWITCHTEC_BOOT_PHASE_BL2) {
@@ -270,8 +273,14 @@ int switchtec_fw_toggle_active_partition(struct switchtec_dev *dev,
 	cmd.toggle_key = !!toggle_key;
 	cmd.toggle_fw = !!toggle_fw;
 	cmd.toggle_cfg = !!toggle_cfg;
+	if (switchtec_is_gen5(dev)) {
+		cmd.toggle_riotcore = !!toggle_riotcore;
+		cmd_size = sizeof(cmd);
+	} else {
+		cmd_size = sizeof(cmd) - 1;
+	}
 
-	return switchtec_cmd(dev, cmd_id, &cmd, sizeof(cmd),
+	return switchtec_cmd(dev, cmd_id, &cmd, cmd_size,
 			     NULL, 0);
 }
 


### PR DESCRIPTION
Riotcore option added to the fw-toggle command. Updated to the new spec to include new 8bit field to toggle the riotcore.

Added print fw part line for RIOT in inactive and active sections of the fw_info command and fw_toggle command.