### PR TITLE
Fix egress bit encoding in event counter setup, add direction to evcntr output

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -2622,7 +2622,12 @@ static int display_event_counters(struct switchtec_dev *dev, int stack,
 		if (strlen(buf) > 39)
 			strcpy(buf, "MANY");
 
-		printf("%-40s   %10u\n", buf, counts[i]);
+		if (setups[i].type_mask & ALL_TLPS)
+			printf("%-40s   %-8s   %10u\n", buf,
+			       setups[i].egress ? "EGRESS" : "INGRESS",
+			       counts[i]);
+		else
+			printf("%-40s   %-8s   %10u\n", buf, "", counts[i]);
 		count++;
 	}
 

--- a/inc/switchtec/pmon.h
+++ b/inc/switchtec/pmon.h
@@ -28,6 +28,9 @@
 #include <stdint.h>
 #include <switchtec/switchtec.h>
 
+#define SWITCHTEC_PMON_EVENT_EGRESS 0x80
+#define SWITCHTEC_PMON_EVENT_INGRESS 0x00
+
 #pragma pack(push, 1)
 
 struct pmon_event_counter_setup {

--- a/lib/pmon.c
+++ b/lib/pmon.c
@@ -150,7 +150,9 @@ int switchtec_evcntr_setup(struct switchtec_dev *dev, unsigned stack_id,
 			[0] = {
 				.mask = htole32((setup->type_mask << 8) |
 						(setup->port_mask & 0xFF)),
-				.ieg = setup->egress,
+				.ieg = (setup->egress ? SWITCHTEC_PMON_EVENT_EGRESS :
+							SWITCHTEC_PMON_EVENT_INGRESS) |
+				       ((setup->type_mask >> 24) & 0x7F),
 				.thresh = htole32(setup->threshold),
 			},
 		},
@@ -231,9 +233,12 @@ int switchtec_evcntr_get_setup(struct switchtec_dev *dev, unsigned stack_id,
 		return ret;
 
 	for (i = 0; i < nr_cntrs; i++) {
-		res[i].port_mask = le32toh(data[i].mask) & 0xFF;
-		res[i].type_mask = le32toh(data[i].mask) >> 8;
-		res[i].egress = data[i].ieg;
+		uint32_t m = le32toh(data[i].mask);
+
+		res[i].port_mask = m & 0xFF;
+		res[i].type_mask = ((m >> 8) & 0xFFFFFF) |
+				   ((data[i].ieg & 0x7F) << 24);
+		res[i].egress = (data[i].ieg >> 7) & 1;
 		res[i].threshold = le32toh(data[i].thresh);
 	}
 


### PR DESCRIPTION

### Problem

The ingress/egress direction bit was being encoded incorrectly in the `MRPC_PMON_SETUP_EV_COUNTER` input. Per the firmware spec, the I/E bit is bit 7 of the byte following the 32-bit mask field (alongside type mask bits 24–30 in bits 6:0). The code was writing the ieg byte as `0x01` into that byte instead of `0x80`, so the firmware always saw ingress (and a corrupt type mask bit 24). On readback, `evcntr-show` would display `INGRESS` regardless of how the counter was configured. Additionally, type mask bits 24–30 were not being included in that byte on write, nor recovered on readback.

### Changes
#### pmon: fix egress bit encoding and decoding in event counter setup
**`lib/pmon.c`**
- Fix `switchtec_evcntr_setup` to set bit 7 of the `ieg` byte for egress (`0x80`) and pack type mask bits 24–30 into bits 6:0
- Fix `switchtec_evcntr_get_setup` to extract the egress flag from bit 7 of `ieg` and recover type mask bits 24–30 from bits 6:0

#### evcntr: display ingress/egress direction in event counter output
**`cli/main.c`**
- Add `INGRESS`/`EGRESS` label to `evcntr` output for counters measuring TLP types, where direction is meaningful

### Testing

Configured 11 event counters on a G4 PFX device covering all TLP types in both directions, plus some error counters. `evcntr` output correctly shows direction for TLP counters and omits it for error counters. `evcntr-show` correctly reads back the configured direction:

#### Event Counter Setup
```
$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 0 --event ALL_TLPS --port_mask 6
Stack:     3
Counter:   0
Ports:     6
Events:    ALL_TLPS
Direction: INGRESS
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 1 --event ALL_TLPS --egress --port_mask 6
Stack:     3
Counter:   1
Ports:     6
Events:    ALL_TLPS
Direction: EGRESS
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 2 --event POSTED_TLP --port_mask 6
Stack:     3
Counter:   2
Ports:     6
Events:    POSTED_TLP
Direction: INGRESS
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 3 --event POSTED_TLP --egress --port_mask 6
Stack:     3
Counter:   3
Ports:     6
Events:    POSTED_TLP
Direction: EGRESS
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 4 --event COMP_TLP --port_mask 6
Stack:     3
Counter:   4
Ports:     6
Events:    COMP_TLP
Direction: INGRESS
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 5 --event COMP_TLP --egress --port_mask 6
Stack:     3
Counter:   5
Ports:     6
Events:    COMP_TLP
Direction: EGRESS
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 6 --event NON_POSTED_TLP --port_mask 6
Stack:     3
Counter:   6
Ports:     6
Events:    NON_POSTED_TLP
Direction: INGRESS
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 7 --event NON_POSTED_TLP --egress --port_mask 6
Stack:     3
Counter:   7
Ports:     6
Events:    NON_POSTED_TLP
Direction: EGRESS
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 8 --event RCVR_ERR
Stack:     3
Counter:   8
Ports:     ALL
Events:    RCVR_ERR
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 9 --event RCV_FATAL_MSG --port_mask 6
Stack:     3
Counter:   9
Ports:     6
Events:    RCV_FATAL_MSG
evcntr-setup: Success

$ ./switchtec evcntr-setup /dev/switchtec0 --stack 3 --counter 10 --event BAD_DLLP
Stack:     3
Counter:   10
Ports:     ALL
Events:    BAD_DLLP
evcntr-setup: Success
```

#### Show Counter Configuration
```
$ ./switchtec evcntr-show switchtec0 --stack=3 --counter=6
Stack:     3
Counter:   6
Ports:     6
Events:    NON_POSTED_TLP
Direction: INGRESS

$ ./switchtec evcntr-show switchtec0 --stack=3 --counter=7
Stack:     3
Counter:   7
Ports:     6
Events:    NON_POSTED_TLP
Direction: EGRESS

$ ./switchtec evcntr-show switchtec0 --stack=3 --counter=8
Stack:     3
Counter:   8
Ports:     ALL
Events:    RCVR_ERR

$ ./switchtec evcntr-show switchtec0 --stack=3 --counter=9
Stack:     3
Counter:   9
Ports:     6
Events:    RCV_FATAL_MSG

$ ./switchtec evcntr-show switchtec0 --stack=3 --counter=10
Stack:     3
Counter:   10
Ports:     ALL
Events:    BAD_DLLP

$ ./switchtec evcntr-show switchtec0 --stack=3 --counter=11
Stack:     3
Counter:   11
Not Configured.
```

#### Read Counters
```
$ ./switchtec evcntr switchtec0 --stack=3
Stack 3:
    0 - 6          ALL_TLPS                                   INGRESS             0
    1 - 6          ALL_TLPS                                   EGRESS             36
    2 - 6          POSTED_TLP                                 INGRESS             0
    3 - 6          POSTED_TLP                                 EGRESS              2
    4 - 6          COMP_TLP                                   INGRESS             0
    5 - 6          COMP_TLP                                   EGRESS              0
    6 - 6          NON_POSTED_TLP                             INGRESS             0
    7 - 6          NON_POSTED_TLP                             EGRESS             34
    8 - ALL        RCVR_ERR                                                       0
    9 - 6          RCV_FATAL_MSG                                                  0
   10 - ALL        BAD_DLLP                                                       0
```