### PR TITLE
Info compat fix

### DIFF
--- a/lib/mfg.c
+++ b/lib/mfg.c
@@ -2340,6 +2340,11 @@ static int sn_ver_get_gen6(struct switchtec_dev *dev,
 
 	ret = switchtec_mfg_cmd(dev, MRPC_SN_VER_GET_GEN6, &subcmd, 4,
 						    &reply, sizeof(reply));
+	if (ret && subcmd == GEN6_SN_VER_GET_SUBCMD_POST_BL1) {
+		subcmd = GEN6_SN_VER_GET_SUBCMD_BL1;
+		ret = switchtec_mfg_cmd(dev, MRPC_SN_VER_GET_GEN6, &subcmd, 4,
+					&reply, sizeof(reply));
+	}
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
The B012 firmware (0a050012) does not support subcmd=1 for MRPC 0x124 returns error 0x7d020. The newer B013 firmware (0a060013) does support it. Since both subcmds return the same reply struct, this is a firmware feature-level incompatibility. Add fallback if first subcmd=1 case fails