### PR TITLE
Revert "Add debug token part option to fw-toggle cmd"

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -2226,7 +2226,6 @@ static int fw_toggle(int argc, char **argv)
 		int firmware;
 		int config;
 		int riotcore;
-		int debug_token;
 	} cfg = {};
 	const struct argconfig_options opts[] = {
 		DEVICE_OPTION,
@@ -2240,26 +2239,19 @@ static int fw_toggle(int argc, char **argv)
 		 "toggle CFG data"},
 		{"riotcore", 'r', "", CFG_NONE, &cfg.riotcore, no_argument,
 		 "toggle RIOTCORE - Gen5 switch only"},
-		{"debug-token", 'd', "", CFG_NONE, &cfg.debug_token, no_argument,
-		 "toggle Debug Token image - Gen6 switch only"},
 		{NULL}};
 
 	argconfig_parse(argc, argv, CMD_DESC_FW_TOGGLE, opts, &cfg, sizeof(cfg));
 
-	if (!cfg.bl2 && !cfg.key && !cfg.firmware && !cfg.config &&
-	    !cfg.riotcore && !cfg.debug_token) {
+	if (!cfg.bl2 && !cfg.key && !cfg.firmware && !cfg.config && !cfg.riotcore) {
 		fprintf(stderr, "NOTE: Not toggling images as no "
 			"partition type options were specified\n\n");
-	} else if ((cfg.bl2 || cfg.key || cfg.riotcore || cfg.debug_token) && 
-		    switchtec_is_gen3(cfg.dev)) {
-		fprintf(stderr, "Firmware type BL2, Key manifest, or RIORCORE or Debug Token"
+	} else if ((cfg.bl2 || cfg.key || cfg.riotcore) && switchtec_is_gen3(cfg.dev)) {
+		fprintf(stderr, "Firmware type BL2, Key manifest, or RIORCORE "
 			"are not supported by Gen3 switches\n");
 		return 1;
-	} else if (cfg.riotcore && !switchtec_is_gen5(cfg.dev)){
-		fprintf(stderr, "Firmware type RIOTCORE is only supported by Gen5 switches\n");
-		return 1;
-	} else if (cfg.debug_token && !switchtec_is_gen6(cfg.dev)) {
-		fprintf(stderr, "Firmware type Debug Token is only supported by Gen6 switches\n");
+	} else if (cfg.riotcore && switchtec_is_gen4(cfg.dev)){
+		fprintf(stderr, "Firmware type RIOTCORE is not supported by Gen4 switches\n");
 		return 1;
 	} else {
 		ret = switchtec_fw_toggle_active_partition(cfg.dev,
@@ -2267,8 +2259,7 @@ static int fw_toggle(int argc, char **argv)
 							   cfg.key,
 							   cfg.firmware,
 							   cfg.config,
-							   cfg.riotcore,
-							   cfg.debug_token);
+							   cfg.riotcore);
 		if (ret)
 			err = errno;
 	}

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -1096,8 +1096,7 @@ int switchtec_fw_set_redundant_flag(struct switchtec_dev *dev,
 int switchtec_fw_toggle_active_partition(struct switchtec_dev *dev,
 					 int toggle_bl2, int toggle_key,
 					 int toggle_fw, int toggle_cfg,
-					 int toggle_riotcore,
-					 int toggle_debug_token);
+					 int toggle_riotcore);
 int switchtec_fw_debug_token_part_erase(struct switchtec_dev *dev);
 int switchtec_fw_write_fd(struct switchtec_dev *dev, int img_fd,
 			  int dont_activate, int force,

--- a/lib/fw.c
+++ b/lib/fw.c
@@ -477,8 +477,7 @@ static int switchtec_cmd_nopoll(struct switchtec_dev *dev, uint32_t cmd_id,
 int switchtec_fw_toggle_active_partition(struct switchtec_dev *dev,
 					 int toggle_bl2, int toggle_key,
 					 int toggle_fw, int toggle_cfg,
-					 int toggle_riotcore,
-					 int toggle_debug_token)
+					 int toggle_riotcore)
 {
 	uint32_t cmd_id;
 	size_t cmd_size;
@@ -489,10 +488,8 @@ int switchtec_fw_toggle_active_partition(struct switchtec_dev *dev,
 		uint8_t toggle_cfg;
 		uint8_t toggle_bl2;
 		uint8_t toggle_key;
-		union {
-			uint8_t toggle_riotcore;
-			uint8_t toggle_debug_token;
-		};
+		uint8_t toggle_riotcore;
+		uint16_t reserved;
 	} cmd;
 
 	if (switchtec_boot_phase(dev) == SWITCHTEC_BOOT_PHASE_BL2) {
@@ -539,17 +536,9 @@ int switchtec_fw_toggle_active_partition(struct switchtec_dev *dev,
 	cmd.toggle_key = !!toggle_key;
 	cmd.toggle_fw = !!toggle_fw;
 	cmd.toggle_cfg = !!toggle_cfg;
-	cmd.toggle_riotcore = 0;
-
-	if (switchtec_is_gen5(dev)) {
+	if (switchtec_is_gen5(dev))
 		cmd.toggle_riotcore = !!toggle_riotcore;
-		cmd_size = sizeof(cmd);
-	} else if (switchtec_is_gen6(dev)) {
-		cmd.toggle_debug_token = !!toggle_debug_token;
-		cmd_size = sizeof(cmd);
-	} else {
-		cmd_size = sizeof(cmd) - 1;
-	}
+	cmd_size = sizeof(cmd);
 
 	return switchtec_cmd(dev, cmd_id, &cmd, cmd_size,
 			     NULL, 0);


### PR DESCRIPTION
This reverts commit 4a3bcac8cd6f0b95844a5e994f504f3f1a43a1da.
This feature was added without full support in the firmware release.