### PR TITLE
Fix I/O issue with eye cap inband

### DIFF
--- a/lib/diag.c
+++ b/lib/diag.c
@@ -30,8 +30,9 @@
 #define SWITCHTEC_LIB_CORE
 #define SWITCHTEC_LTSSM_MAX_LOGS 61
 #define EYE_CAP_STATUS_TIMEOUT_MS (5 * 60 * 1000)
-#define EYE_CAP_STATUS_POLL_MS 200
-#define EYE_CAP_PROGRESS_INTERVAL 25
+#define EYE_CAP_STATUS_POLL_MS 2000
+#define EYE_CAP_STATUS_RETRY_MS 6000
+#define EYE_CAP_PROGRESS_INTERVAL 5
 
 #include "switchtec_priv.h"
 #include "switchtec/diag.h"
@@ -41,6 +42,7 @@
 
 #include <errno.h>
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 #include <strings.h>
 #include <unistd.h>
@@ -144,9 +146,15 @@ static int switchtec_diag_eye_status_gen5(struct switchtec_dev *dev)
 	struct switchtec_gen5_diag_eye_status_out out;
 
 	do {
-		ret = switchtec_cmd(dev, MRPC_GEN5_EYE_CAPTURE, &in, sizeof(in),
-				    &out, sizeof(out));
+		ret = switchtec_cmd(dev, MRPC_GEN5_EYE_CAPTURE, &in,
+				    sizeof(in), &out, sizeof(out));
 		if (ret) {
+			if (errno == EIO) {
+				usleep(EYE_CAP_STATUS_RETRY_MS * 1000);
+				elapsed_ms += EYE_CAP_STATUS_RETRY_MS;
+				if (elapsed_ms < EYE_CAP_STATUS_TIMEOUT_MS)
+					continue;
+			}
 			switchtec_perror("eye_status");
 			return -1;
 		}

--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -364,7 +364,7 @@ static int read_resp(struct switchtec_linux *ldev, void *resp,
 	memcpy(&ret, buf, sizeof(ret));
 
 	if (ret) {
-		errno = ret; 
+		errno = ret;
 		return ret;
 	}
 
@@ -374,6 +374,22 @@ static int read_resp(struct switchtec_linux *ldev, void *resp,
 	memcpy(resp, &buf[sizeof(ret)], resp_len);
 
 	return ret;
+}
+
+static int linux_reopen_fd(struct switchtec_linux *ldev)
+{
+	char path[PATH_MAX];
+	int new_fd;
+
+	snprintf(path, sizeof(path), "/proc/self/fd/%d", ldev->fd);
+
+	new_fd = open(path, O_RDWR | O_CLOEXEC);
+	if (new_fd < 0)
+		return -1;
+
+	close(ldev->fd);
+	ldev->fd = new_fd;
+	return 0;
 }
 
 static int linux_cmd(struct switchtec_dev *dev,  uint32_t cmd,
@@ -394,7 +410,12 @@ retry:
 	if (ret < 0)
 		return ret;
 
-	return read_resp(ldev, resp, resp_len);
+	ret = read_resp(ldev, resp, resp_len);
+	if (ret < 0 && errno == EIO) {
+		linux_reopen_fd(ldev);
+	}
+
+	return ret;
 }
 
 static int get_class_devices(const char *searchpath,


### PR DESCRIPTION
Linux kernel switchtec driver has roughly 500ms set as a timeout for the MRPC command, if firmware does not respond in that time we see kernel time out and the MRPC state comes back as IO_ERROR and subsequent read() calls return -EIO when attempting another MRPC command.

The fix in this commit is when read_resp() returns EIO we will reopen the device using the file desc. This will reset kernel MRPC state allowing next command to succeed. If switchtec_cmd returns EIO in the eye status command, we should wait 6 seconds (firmware to catch up & finish) and then retry, up to 5 mins timeout. Increase poll interval from 200 to 2000 to reduce contention.