### PR TITLE
Add check if in MRPC error range

### DIFF
--- a/lib/fw.c
+++ b/lib/fw.c
@@ -853,6 +853,10 @@ void switchtec_fw_perror(const char *s, int ret)
 	case SWITCHTEC_DLSTAT_NO_FILE:
 		msg = "No Image Transferred"; break;
 	default:
+		if (errno & SWITCHTEC_ERRNO_MRPC_FLAG_BIT) {
+			switchtec_perror(s);
+			return;
+		}
 		fprintf(stderr, "%s: Unknown Error (0x%x)\n", s, ret);
 		return;
 	}


### PR DESCRIPTION
When a Switchtec device is in INITIALIZED_SECURED state (locked), firmware denies certain MRPC commands with error code 0x64010 (ERR_MRPC_DENIED). Some commands correctly report "MRPC request denied" (fw-info), while others report "Unknown Error (0x64010)" (fw-update, mfg fw-transfer, mfg fw-execute).

Modify switchtec_fw_perror() in lib/fw.c to check whether the return value falls in the 0x64xxx range or matches known MRPC error codes and, if so, fall through to switchtec_perror() which already handles all MRPC errors correctly.